### PR TITLE
Add glass overlay and rounded edges to terminal display

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,9 +110,7 @@
     position:absolute;
     top:0;left:0;right:0;bottom:0;
     pointer-events:none;
-    background:
-      radial-gradient(circle at 10% 10%, rgba(255,255,255,0.25), rgba(255,255,255,0) 60%),
-      linear-gradient(135deg, rgba(255,255,255,0.4), rgba(255,255,255,0.1) 40%, rgba(255,255,255,0) 60%);
+    background:linear-gradient(135deg, rgba(255,255,255,0.25), rgba(255,255,255,0.0625) 40%, rgba(255,255,255,0) 60%);
     border-radius:inherit;
   }
   #terminal::after{

--- a/index.html
+++ b/index.html
@@ -110,7 +110,9 @@
     position:absolute;
     top:0;left:0;right:0;bottom:0;
     pointer-events:none;
-    background:linear-gradient(135deg, rgba(255,255,255,0.2), rgba(255,255,255,0.05) 40%, rgba(255,255,255,0) 60%);
+    background:
+      radial-gradient(circle at 10% 10%, rgba(255,255,255,0.25), rgba(255,255,255,0) 60%),
+      linear-gradient(135deg, rgba(255,255,255,0.4), rgba(255,255,255,0.1) 40%, rgba(255,255,255,0) 60%);
     border-radius:inherit;
   }
   #terminal::after{
@@ -125,6 +127,11 @@
       transparent 2px
     );
     border-radius:inherit;
+    animation: roll 6s linear infinite;
+  }
+  @keyframes roll{
+    from{background-position:0 0;}
+    to{background-position:0 100%;}
   }
   #header, #content{
     white-space:pre-wrap;

--- a/index.html
+++ b/index.html
@@ -105,14 +105,6 @@
   #volume-controls input[type=range]{
     margin-left:5px;
   }
-  #terminal::before{
-    content:"";
-    position:absolute;
-    top:0;left:0;right:0;bottom:0;
-    pointer-events:none;
-    background:linear-gradient(135deg, rgba(255,255,255,0.25), rgba(255,255,255,0.0625) 40%, rgba(255,255,255,0) 60%);
-    border-radius:inherit;
-  }
   #terminal::after{
     content:"";
     position:absolute;

--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@
     display:none;
     flex-direction:column;
     background:#041204;
+    border-radius:12px;
   }
   #terminal.powered{
     display:flex;
@@ -104,6 +105,14 @@
   #volume-controls input[type=range]{
     margin-left:5px;
   }
+  #terminal::before{
+    content:"";
+    position:absolute;
+    top:0;left:0;right:0;bottom:0;
+    pointer-events:none;
+    background:linear-gradient(135deg, rgba(255,255,255,0.2), rgba(255,255,255,0.05) 40%, rgba(255,255,255,0) 60%);
+    border-radius:inherit;
+  }
   #terminal::after{
     content:"";
     position:absolute;
@@ -115,6 +124,7 @@
       transparent 1px,
       transparent 2px
     );
+    border-radius:inherit;
   }
   #header, #content{
     white-space:pre-wrap;


### PR DESCRIPTION
## Summary
- Round terminal screen edges and add glass-like overlay
- Include CRT scan line effect respecting rounded corners

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d546f95083299f45fe4985363145