### PR TITLE
Style terminal like Philco Predicta TV

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
   }
   #terminal-wrapper{
     position:relative;
-    width:44vw;
+    width:48vw;
     height:64vh;
   }
   #power-screen{
@@ -45,12 +45,12 @@
     height:100%;
     border:4px solid #008800;
     box-sizing:border-box;
-    padding:10px;
+    padding:6vh 5vw 8vh;
     overflow:hidden;
     display:none;
     flex-direction:column;
     background:#041204;
-    border-radius:12px;
+    border-radius:50%/40%;
   }
   #terminal.powered{
     display:flex;

--- a/index.html
+++ b/index.html
@@ -5,18 +5,18 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>RobCo Engineering Division Database</title>
 <style>
-  @font-face{
-    font-family:"FixedsysExcelsior";
-    src:local("Fixedsys Excelsior 3.01"),url("./fonts/FixedsysExcelsior.ttf") format("truetype");
-    font-weight:400;
-    font-style:normal;
-    font-display:swap;
-  }
+    @font-face{
+      font-family:"Fixedsys Excelsior 3.01";
+      src:url("fonts/FixedsysExcelsior.ttf") format("truetype");
+      font-weight:400;
+      font-style:normal;
+      font-display:swap;
+    }
   body{
     margin:0;
     background:#000;
     color:#7aff7a;
-    font-family:"FixedsysExcelsior","IBM Plex Mono",ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Courier New",monospace;
+      font-family:"Fixedsys Excelsior 3.01","IBM Plex Mono",ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Courier New",monospace;
     font-size:24px;
     letter-spacing:.25px;
     line-height:1.2;
@@ -25,15 +25,15 @@
     align-items:center;
     height:100vh;
   }
-  #terminal-wrapper{
-    position:relative;
-    width:90vmin;
-    max-width:90vw;
-    max-height:90vh;
-    aspect-ratio:4/3;
-    border-radius:50%/40%;
-    overflow:hidden;
-  }
+    #terminal-wrapper{
+      position:relative;
+      width:90vmin;
+      max-width:90vw;
+      max-height:90vh;
+      aspect-ratio:4/3;
+      border-radius:50%/40%;
+      overflow:visible;
+    }
   #power-screen{
     position:absolute;
     top:0;left:0;right:0;bottom:0;

--- a/index.html
+++ b/index.html
@@ -27,8 +27,8 @@
   }
   #terminal-wrapper{
     position:relative;
-    width:64vw;
-    height:48vh;
+    width:44vw;
+    height:64vh;
   }
   #power-screen{
     position:absolute;
@@ -50,7 +50,7 @@
     display:none;
     flex-direction:column;
     background:#041204;
-    border-radius:15%/12%;
+    border-radius:20%/15%;
   }
   #terminal.powered{
     display:flex;
@@ -72,7 +72,7 @@
     height:48px;
     background:#3f3b2e;
     border:2px solid #008800;
-    border-radius:50%;
+    border-radius:6px;
     cursor:pointer;
   }
 
@@ -86,7 +86,7 @@
     height:60%;
     background:#b3410e;
     border:2px solid #63300a;
-    border-radius:50%;
+    border-radius:4px;
   }
   #audio-menu{
     position:absolute;

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
   }
   #terminal-wrapper{
     position:relative;
-    width:60em;
+    width:90vmin;
     max-width:90vw;
     max-height:90vh;
     aspect-ratio:4/3;
@@ -45,7 +45,7 @@
     position:relative;
     width:100%;
     height:100%;
-    border:4px solid #008800;
+    border:max(4px,0.6vmin) solid #008800;
     box-sizing:border-box;
     padding:3em 2.5em 4em;
     overflow:hidden;

--- a/index.html
+++ b/index.html
@@ -6,9 +6,9 @@
 <title>RobCo Engineering Division Database</title>
 <style>
   @font-face{
-    font-family:"Fixedsys Excelsior 3.01";
-    src:url("fonts/FixedsysExcelsior.ttf") format("truetype");
-    font-weight:normal;
+    font-family:"FixedsysExcelsior";
+    src:local("Fixedsys Excelsior 3.01"),url("./fonts/FixedsysExcelsior.ttf") format("truetype");
+    font-weight:400;
     font-style:normal;
     font-display:swap;
   }
@@ -16,7 +16,7 @@
     margin:0;
     background:#000;
     color:#7aff7a;
-    font-family:"Fixedsys Excelsior 3.01","IBM Plex Mono",ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Courier New",monospace;
+    font-family:"FixedsysExcelsior","IBM Plex Mono",ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Courier New",monospace;
     font-size:24px;
     letter-spacing:.25px;
     line-height:1.2;
@@ -31,6 +31,8 @@
     max-width:90vw;
     max-height:90vh;
     aspect-ratio:4/3;
+    border-radius:50%/40%;
+    overflow:hidden;
   }
   #power-screen{
     position:absolute;
@@ -47,12 +49,12 @@
     height:100%;
     border:max(4px,0.6vmin) solid #008800;
     box-sizing:border-box;
-    padding:3em 2.5em 4em;
+    padding:4em 3em 5em;
     overflow:hidden;
     display:none;
     flex-direction:column;
     background:#041204;
-    border-radius:20%/15%;
+    border-radius:50%/40%;
   }
   #terminal.powered{
     display:flex;

--- a/index.html
+++ b/index.html
@@ -6,17 +6,17 @@
 <title>RobCo Engineering Division Database</title>
 <style>
   @font-face{
-    font-family:"Fixedsys Excelsior";
-    src:url("fonts/FixedsysExcelsior.ttf") format("truetype"),
-        local("Fixedsys Excelsior 3.01"), local("Fixedsys Excelsior"), local("FixedsysExcelsior");
+    font-family:"Fixedsys Excelsior 3.01";
+    src:url("fonts/FixedsysExcelsior.ttf") format("truetype");
     font-weight:normal;
     font-style:normal;
+    font-display:swap;
   }
   body{
     margin:0;
     background:#000;
     color:#7aff7a;
-    font-family:"Fixedsys Excelsior","IBM Plex Mono",ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Courier New",monospace;
+    font-family:"Fixedsys Excelsior 3.01","IBM Plex Mono",ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Courier New",monospace;
     font-size:24px;
     letter-spacing:.25px;
     line-height:1.2;
@@ -27,8 +27,10 @@
   }
   #terminal-wrapper{
     position:relative;
-    width:44vw;
-    height:64vh;
+    width:60em;
+    max-width:90vw;
+    max-height:90vh;
+    aspect-ratio:4/3;
   }
   #power-screen{
     position:absolute;
@@ -45,7 +47,7 @@
     height:100%;
     border:4px solid #008800;
     box-sizing:border-box;
-    padding:6vh 5vw 8vh;
+    padding:3em 2.5em 4em;
     overflow:hidden;
     display:none;
     flex-direction:column;
@@ -72,7 +74,7 @@
     height:48px;
     background:#3f3b2e;
     border:2px solid #008800;
-    border-radius:6px;
+    border-radius:50%;
     cursor:pointer;
   }
 
@@ -86,7 +88,7 @@
     height:60%;
     background:#b3410e;
     border:2px solid #63300a;
-    border-radius:4px;
+    border-radius:50%;
   }
   #audio-menu{
     position:absolute;

--- a/index.html
+++ b/index.html
@@ -27,8 +27,8 @@
   }
   #terminal-wrapper{
     position:relative;
-    width:48vw;
-    height:64vh;
+    width:64vw;
+    height:48vh;
   }
   #power-screen{
     position:absolute;
@@ -50,7 +50,7 @@
     display:none;
     flex-direction:column;
     background:#041204;
-    border-radius:50%/40%;
+    border-radius:15%/12%;
   }
   #terminal.powered{
     display:flex;
@@ -67,14 +67,26 @@
     margin-right:5px;
   }
   #power-button{
-    background:#b3410e;
-    color:#fff;
+    position:relative;
+    width:48px;
+    height:48px;
+    background:#3f3b2e;
     border:2px solid #008800;
-    width:40px;
-    height:40px;
-    border-radius:0;
-    font-size:20px;
+    border-radius:50%;
     cursor:pointer;
+  }
+
+  #power-button::before{
+    content:"";
+    position:absolute;
+    top:50%;
+    left:50%;
+    transform:translate(-50%,-50%);
+    width:60%;
+    height:60%;
+    background:#b3410e;
+    border:2px solid #63300a;
+    border-radius:50%;
   }
   #audio-menu{
     position:absolute;
@@ -164,7 +176,7 @@
       <label>Select <input type="range" min="1" max="10" value="5" id="select-volume"></label>
     </div>
   </div>
-  <div id="power-container"><span>Power</span><button id="power-button" aria-label="Power">&#x23FB;</button></div>
+<div id="power-container"><span>Power</span><button id="power-button" aria-label="Power"></button></div>
 </div>
 <script>
 const headerLines=[


### PR DESCRIPTION
## Summary
- Shape the terminal screen like a Fallout Philco Predicta TV with an oval border radius
- Increase inner padding so text and input area stay visible at top and bottom

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1186b006083298c0e8ab09bcc9764