### PR TITLE
Set fixed terminal size and scale on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,8 +27,15 @@
   }
   #terminal-wrapper{
     position:relative;
-    width:44vw;
-    height:64vh;
+    width:640px;
+    height:480px;
+  }
+
+  @media (max-width: 640px), (max-height: 480px) {
+    #terminal-wrapper{
+      transform: scale(min(calc(100vw / 640px), calc(100vh / 480px)));
+      transform-origin: top left;
+    }
   }
   #power-screen{
     position:absolute;


### PR DESCRIPTION
## Summary
- Replace viewport-based dimensions of `#terminal-wrapper` with fixed `640px` by `480px` values
- Scale the terminal with `transform: scale()` when viewport is narrower or shorter than its base size

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b12bf400dc8329bfdbb171ec41729b