### PR TITLE
Fix terminal width scaling and stabilize control buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,9 +32,10 @@
   }
   #terminal-wrapper{
     position:relative;
-    aspect-ratio:44/64;
-    width:min(90vw, 90vh * 44 / 64);
-    height:auto;
+    width:44vw;
+    height:64vh;
+    max-width:90vw;
+    max-height:90vh;
   }
   #power-screen{
     position:absolute;
@@ -63,10 +64,11 @@
   }
   #power-container{
     position:absolute;
-    bottom:calc(-20px * var(--scale));
-    right:calc(-20px * var(--scale));
+    bottom:0;
+    right:0;
     display:flex;
     align-items:center;
+    transform:translate(calc(20px * var(--scale)), calc(20px * var(--scale)));
   }
   #power-container span{
     color:#7aff7a;
@@ -84,9 +86,10 @@
   }
   #audio-menu{
     position:absolute;
-    bottom:calc(-20px * var(--scale));
-    left:calc(-20px * var(--scale));
+    bottom:0;
+    left:0;
     display:none;
+    transform:translate(calc(-20px * var(--scale)), calc(20px * var(--scale)));
   }
   #audio-toggle{
     background:#b3410e;


### PR DESCRIPTION
## Summary
- Restore terminal window to original 44vw by 64vh sizing while keeping responsive scaling
- Anchor power and audio controls to consistent corners so they no longer shift when powering on/off

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b17c85caa483299cb9f3685fd7f39b