### PR TITLE
Scale terminal wrapper dimensions with CSS clamp

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,8 +32,8 @@
   }
   #terminal-wrapper{
     position:relative;
-    width:44vw;
-    height:64vh;
+    width: clamp(300px, calc(600px * var(--scale)), 90vw);
+    height: clamp(400px, calc(800px * var(--scale)), 90vh);
     max-width:90vw;
     max-height:90vh;
   }


### PR DESCRIPTION
## Summary
- use `clamp()` with `var(--scale)` so terminal wrapper width and height scale with text

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node` script calculating wrapper sizes for varying scales and viewport sizes

------
https://chatgpt.com/codex/tasks/task_e_68b1ad9c2e088329a1b72c61b640bd27