### PR TITLE
chore: allow larger font scaling

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     font-style:normal;
   }
   :root{
-    --scale:clamp(0.7, min(100vw,100vh)/600, 2);
+    --scale:clamp(0.7, min(100vw,100vh)/600, 3);
   }
   body{
     margin:0;


### PR DESCRIPTION
## Summary
- expand CSS `--scale` clamp upper bound so fonts can grow larger on big screens

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node` computed scale for large viewports
- `node` confirmed wrapper size remains within 90% viewport

------
https://chatgpt.com/codex/tasks/task_e_68b1ada9dbf08329b955eeb37c17c7b3