### PR TITLE
Fix terminal window scaling

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     font-style:normal;
   }
   :root{
-    --scale:clamp(0.7, min(100vw,100vh)/600, 3);
+    --scale:1;
   }
   body{
     margin:0;
@@ -32,8 +32,8 @@
   }
   #terminal-wrapper{
     position:relative;
-    width: clamp(300px, calc(600px * var(--scale)), 90vw);
-    height: clamp(400px, calc(800px * var(--scale)), 90vh);
+    width:calc(600px * var(--scale));
+    height:calc(800px * var(--scale));
     max-width:90vw;
     max-height:90vh;
   }
@@ -182,6 +182,12 @@
   <div id="power-container"><span>Power</span><button id="power-button" aria-label="Power">&#x23FB;</button></div>
 </div>
 <script>
+function updateScale(){
+  const scale=Math.min(3,Math.max(0.7,Math.min(window.innerWidth*0.9/600,window.innerHeight*0.9/800)));
+  document.documentElement.style.setProperty('--scale',scale);
+}
+window.addEventListener('resize',updateScale);
+updateScale();
 const headerLines=[
 "ROBCO INDUSTRIES UNIFIED OPERATING SYSTEM",
 "COPYRIGHT 2075-2077 ROBCO INDUSTRIES",


### PR DESCRIPTION
## Summary
- decouple window size from text scaling by computing terminal scale in JS
- keep terminal aspect ratio consistent across screen sizes

## Testing
- `npm test` (fails: package.json not found)


------
https://chatgpt.com/codex/tasks/task_e_68b1cea763fc83298b4ea4c9597ee1ce