### PR TITLE
Use AudioContext for fan hum

### DIFF
--- a/index.html
+++ b/index.html
@@ -310,9 +310,12 @@ let humVolume=humSlider.value/10;
 let scrollVolume=scrollSlider.value/10;
 let focusVolume=focusSlider.value/10;
 let selectVolume=selectSlider.value/10;
-let fanHumAudio;
+let fanHumBuffer,fanHumSource,fanHumGain;
 
-humSlider.addEventListener('input',()=>{humVolume=humSlider.value/10;if(fanHumAudio)fanHumAudio.volume=humVolume;});
+humSlider.addEventListener('input',()=>{
+  humVolume=humSlider.value/10;
+  if(fanHumGain) fanHumGain.gain.value=humVolume;
+});
 scrollSlider.addEventListener('input',()=>{scrollVolume=scrollSlider.value/10;});
 focusSlider.addEventListener('input',()=>{focusVolume=focusSlider.value/10;});
 selectSlider.addEventListener('input',()=>{selectVolume=selectSlider.value/10;});
@@ -323,6 +326,9 @@ function updateInput(){
 updateInput();
 
 const audioCtx=new (window.AudioContext||window.webkitAudioContext)();
+fanHumGain=audioCtx.createGain();
+fanHumGain.gain.value=humVolume;
+fanHumGain.connect(audioCtx.destination);
 
 let scrollBuffer;
 let scrollTimeout;
@@ -369,18 +375,25 @@ function stopScrollSound(){
   scrollTimeout=null;
 }
 
-function startFanHum(){
-  fanHumAudio=new Audio('Terminal 3/fanhum_lp.wav');
-  fanHumAudio.loop=true;
-  fanHumAudio.volume=humVolume;
-  fanHumAudio.play();
+async function startFanHum(){
+  if(!fanHumBuffer){
+    const res=await fetch('Terminal 3/fanhum_lp.wav');
+    const buf=await res.arrayBuffer();
+    fanHumBuffer=await audioCtx.decodeAudioData(buf);
+  }
+  stopFanHum();
+  fanHumSource=audioCtx.createBufferSource();
+  fanHumSource.buffer=fanHumBuffer;
+  fanHumSource.loop=true;
+  fanHumSource.connect(fanHumGain);
+  fanHumSource.start(0);
 }
 
 function stopFanHum(){
-  if(fanHumAudio){
-    fanHumAudio.pause();
-    fanHumAudio.currentTime=0;
-    fanHumAudio=null;
+  if(fanHumSource){
+    fanHumSource.stop();
+    fanHumSource.disconnect();
+    fanHumSource=null;
   }
 }
 


### PR DESCRIPTION
## Summary
- Switch fan hum playback from HTMLAudioElement to Web Audio API with a persistent GainNode
- Allow hum volume slider to control the GainNode's gain
- Stop and disconnect the fan hum AudioBufferSourceNode when powering off

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cf500b608329b63bf8c50df12d97