### PR TITLE
Use bundled Fixedsys font instead of requiring installation

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,7 @@
 <style>
   @font-face{
     font-family:"Fixedsys Excelsior";
-    src:url("fonts/FixedsysExcelsior.ttf") format("truetype"),
-        local("Fixedsys Excelsior 3.01"), local("Fixedsys Excelsior"), local("FixedsysExcelsior");
+    src:url("fonts/FixedsysExcelsior.ttf") format("truetype");
     font-weight:normal;
     font-style:normal;
   }


### PR DESCRIPTION
## Summary
- Always load Fixedsys Excelsior from bundled `fonts/FixedsysExcelsior.ttf` file so users don't need to install the font

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cf1d1c3083298aa28f04986b902c