### PR TITLE
Improve terminal layout and control positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,10 +31,8 @@
   }
   #terminal-wrapper{
     position:relative;
-    width:calc(600px * var(--scale));
+    width:calc(800px * var(--scale));
     height:calc(800px * var(--scale));
-    max-width:90vw;
-    max-height:90vh;
   }
   #power-screen{
     position:absolute;
@@ -67,7 +65,7 @@
     right:0;
     display:flex;
     align-items:center;
-    transform:translate(calc(20px * var(--scale)), calc(20px * var(--scale)));
+    transform:translateY(calc(20px * var(--scale)));
   }
   #power-container span{
     color:#7aff7a;
@@ -88,7 +86,7 @@
     bottom:0;
     left:0;
     display:none;
-    transform:translate(calc(-20px * var(--scale)), calc(20px * var(--scale)));
+    transform:translateY(calc(20px * var(--scale)));
   }
   #audio-toggle{
     background:#b3410e;


### PR DESCRIPTION
## Summary
- Widen terminal wrapper to 800px
- Drop max dimensions so small screens can scroll
- Move power/audio controls beneath window corners

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d164026483299a574defd33c8dca