### PR TITLE
Remove terminal scrolling and shrink height

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
   #terminal-wrapper{
     position:relative;
     width:calc(800px * var(--scale));
-    height:calc(800px * var(--scale));
+    height:calc(720px * var(--scale));
   }
   #power-screen{
     position:absolute;
@@ -140,8 +140,8 @@
   }
   #content{
     flex:1;
-    overflow:auto;
-    -webkit-overflow-scrolling:touch;
+    overflow:hidden;
+    word-break:break-word;
   }
   #input{
     white-space:pre-wrap;


### PR DESCRIPTION
## Summary
- Reduce terminal wrapper height by 10% to avoid clipping on mobile.
- Disable both horizontal and vertical scrolling in the content area while retaining word wrapping.

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68b1eece185883298ca46f049da92b33