### PR TITLE
chore: reduce padding on terminal for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
     height:100%;
     border:calc(4px * var(--scale)) solid #008800;
     box-sizing:border-box;
-    padding:calc(10px * var(--scale));
+    padding:calc(6px * var(--scale));
     overflow:hidden;
     display:none;
     flex-direction:column;
@@ -183,7 +183,16 @@
 </div>
 <script>
 function updateScale(){
-  const scale=Math.min(3,Math.max(0.7,Math.min(window.innerWidth*0.9/600,window.innerHeight*0.9/800)));
+  const scale=Math.min(
+    3,
+    Math.max(
+      0.7,
+      Math.min(
+        window.innerWidth*0.98/600,
+        window.innerHeight*0.98/800
+      )
+    )
+  );
   document.documentElement.style.setProperty('--scale',scale);
 }
 window.addEventListener('resize',updateScale);

--- a/index.html
+++ b/index.html
@@ -15,11 +15,13 @@
     --scale:1;
   }
   html{
-    overflow:hidden;
+    overflow-x:hidden;
+    overflow-y:auto;
   }
   body{
     margin:0;
-    overflow:hidden;
+    overflow-x:hidden;
+    overflow-y:auto;
     background:#000;
     color:#7aff7a;
     font-family:"FSEX300","IBM Plex Mono",ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Courier New",monospace;
@@ -28,7 +30,7 @@
     line-height:1.2;
     display:flex;
     justify-content:center;
-    align-items:center;
+    align-items:flex-start;
     min-height:100vh;
     box-sizing:border-box;
     padding:env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
     align-items:flex-start;
     min-height:100vh;
     box-sizing:border-box;
-    padding:env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+    padding:calc(env(safe-area-inset-top) + 8px) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
   }
   #terminal-wrapper{
     position:relative;
@@ -192,7 +192,7 @@ function updateScale(){
       Math.min(
         window.innerWidth*0.98/600,
         window.innerHeight*0.98/800
-      )
+      )*0.93
     )
   );
   document.documentElement.style.setProperty('--scale',scale);

--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@
     width:100%;
     cursor:pointer;
     padding:0 calc(4px * var(--scale));
-    min-height:max(44px, calc(44px * var(--scale)));
+    min-height:max(32px, calc(32px * var(--scale)));
   }
   .option:hover, .option:focus, .option.selected{
     background:#008800;
@@ -170,10 +170,10 @@
       <button id="audio-toggle" aria-label="Audio">&#x1F50A;</button>
       <span>Audio</span>
       <div id="volume-controls">
-        <label>Hum <input type="range" min="1" max="10" value="2" id="hum-volume"></label>
-        <label>Scroll <input type="range" min="1" max="10" value="5" id="scroll-volume"></label>
-        <label>Focus <input type="range" min="1" max="10" value="5" id="focus-volume"></label>
-        <label>Select <input type="range" min="1" max="10" value="5" id="select-volume"></label>
+        <label>Hum <input type="range" min="0" max="10" value="2" id="hum-volume"></label>
+        <label>Scroll <input type="range" min="0" max="10" value="5" id="scroll-volume"></label>
+        <label>Focus <input type="range" min="0" max="10" value="5" id="focus-volume"></label>
+        <label>Select <input type="range" min="0" max="10" value="5" id="select-volume"></label>
       </div>
     </div>
     <div id="power-container">

--- a/index.html
+++ b/index.html
@@ -25,8 +25,8 @@
     background:#000;
     color:#7aff7a;
     font-family:"FSEX300","IBM Plex Mono",ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Courier New",monospace;
-    font-size:calc(24px * var(--scale));
-    letter-spacing:calc(.25px * var(--scale));
+    font-size:calc(24px * var(--scale) * 0.9);
+    letter-spacing:calc(.25px * var(--scale) * 0.9);
     line-height:1.2;
     display:flex;
     justify-content:center;
@@ -67,12 +67,11 @@
   }
   #controls-container{
     position:absolute;
-    bottom:0;
-    right:0;
+    top:calc(100% + (20px * var(--scale)));
+    left:calc(100% + (20px * var(--scale)));
     display:flex;
     flex-direction:column;
     align-items:center;
-    transform:translate(calc(20px * var(--scale)), calc(20px * var(--scale)));
   }
   #power-container, #audio-menu{
     display:flex;
@@ -90,7 +89,7 @@
     width:max(44px, calc(40px * var(--scale)));
     height:max(44px, calc(40px * var(--scale)));
     border-radius:0;
-    font-size:calc(20px * var(--scale));
+    font-size:calc(20px * var(--scale) * 0.9);
     cursor:pointer;
   }
   #power-container{margin-top:calc(10px * var(--scale));}
@@ -106,7 +105,7 @@
   #volume-controls label{
     display:flex;
     align-items:center;
-    font-size:calc(12px * var(--scale));
+    font-size:calc(12px * var(--scale) * 0.9);
     margin-right:calc(10px * var(--scale));
   }
   #volume-controls input[type=range]{

--- a/index.html
+++ b/index.html
@@ -67,20 +67,28 @@
   }
   #controls-container{
     position:absolute;
-    top:calc(100% + (20px * var(--scale)));
     left:calc(100% + (20px * var(--scale)));
+    bottom:0;
     display:flex;
     flex-direction:column;
     align-items:center;
+    justify-content:flex-end;
   }
   #power-container, #audio-menu{
+    position:relative;
     display:flex;
     flex-direction:column;
     align-items:center;
   }
-  #controls-container span{
-    color:#7aff7a;
+  #controls-container span{color:#7aff7a;}
+  #audio-menu span{
     margin-top:calc(5px * var(--scale));
+  }
+  #power-container span{
+    position:absolute;
+    top:calc(100% + (5px * var(--scale)));
+    left:50%;
+    transform:translateX(-50%);
   }
   #power-button, #audio-toggle{
     background:#b3410e;
@@ -92,8 +100,10 @@
     font-size:calc(20px * var(--scale) * 0.9);
     cursor:pointer;
   }
-  #power-container{margin-top:calc(10px * var(--scale));}
-  #audio-menu{display:none;}
+  #audio-menu{
+    display:none;
+    margin-bottom:calc(10px * var(--scale));
+  }
   #volume-controls{
     display:none;
     background:#041204;


### PR DESCRIPTION
## Summary
- shrink terminal inner padding for more usable space
- enlarge mobile view by updating scale calculation

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b223975bcc83299e85ca2790802fe4