### PR TITLE
Enhance terminal scan line visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,12 +126,14 @@
     position:absolute;
     top:0;left:0;right:0;bottom:0;
     pointer-events:none;
+    z-index:1;
     background:repeating-linear-gradient(
       rgba(0,0,0,0.55) 0px,
-      rgba(0,0,0,0.55) 1px,
-      transparent 1px,
-      transparent 2px
+      rgba(0,0,0,0.55) 2px,
+      transparent 2px,
+      transparent 4px
     );
+    mix-blend-mode:multiply;
     border-radius:inherit;
     animation: roll 6s linear infinite;
   }


### PR DESCRIPTION
## Summary
- Make scan-line overlay thicker and more prominent using a 2px repeating gradient and multiply blend
- Ensure scan-line overlay stays above terminal content with z-index

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b238fcd91c8329ba364f880d2eca90