### PR TITLE
Slow CRT band animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,12 +151,12 @@
     );
     mix-blend-mode:multiply;
     border-radius:inherit;
-    animation:crt-band 4s linear infinite;
+    animation:crt-band 5.6s linear infinite;
     z-index:2;
   }
   #terminal::after{
     opacity:0.5;
-    animation-delay:-2s;
+    animation-delay:-2.8s;
   }
   @keyframes crt-band{
     from{transform:translateY(-100%);}


### PR DESCRIPTION
## Summary
- slow rolling CRT band animation by 40%

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Terminal/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b24b51e0cc8329926a51b6d5ddbc6d