### PR TITLE
Center title information

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,11 +242,13 @@ function updateScale(){
 }
 window.addEventListener('resize',updateScale);
 updateScale();
-const headerLines=[
+const titleLines=[
 "ROBCO INDUSTRIES UNIFIED OPERATING SYSTEM",
 "COPYRIGHT 2075-2077 ROBCO INDUSTRIES",
 "-Server 12-",
 "",
+];
+const headerLines=[
 "Welcome to the RobCo Engineering Division Database!",
 "How may I assist you this fine day?",
 "____________________________________________________",
@@ -546,8 +548,16 @@ document.addEventListener('keydown',e=>{
 
 async function init(){
   startScrollSound();
+  for(const line of titleLines){
+    const div=document.createElement('div');
+    div.style.textAlign='center';
+    header.appendChild(div);
+    await typeText(div,line);
+  }
   for(const line of headerLines){
-    await typeText(header,line);
+    const div=document.createElement('div');
+    header.appendChild(div);
+    await typeText(div,line);
   }
   stopScrollSound();
   showScreen('menu');


### PR DESCRIPTION
## Summary
- Center splash-title lines for the RobCo terminal while keeping subsequent header text left-aligned
- Refactor header rendering into separate title and header sections

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b25ba375b08329b3e840a246250089