### PR TITLE
feat: enable mobile text input

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,6 +185,18 @@
   #input{
     white-space:pre-wrap;
     min-height:1.2em;
+    outline:none;
+    caret-color:transparent;
+  }
+  #hidden-input{
+    position:absolute;
+    opacity:0;
+    pointer-events:none;
+    caret-color:transparent;
+    outline:none;
+    border:none;
+    width:0;
+    height:0;
   }
   .option{
     display:flex;
@@ -209,6 +221,7 @@
     <div id="header"></div>
     <div id="content"></div>
     <div id="input"></div>
+    <input id="hidden-input" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
   </div>
   <div id="controls-container">
     <div id="audio-menu">
@@ -347,6 +360,7 @@ const powerScreen=document.getElementById('power-screen');
 const header=document.getElementById('header');
 const content=document.getElementById('content');
 const input=document.getElementById('input');
+const hiddenInput=document.getElementById('hidden-input');
 let currentOptions=[];
 let selected=-1;
 let typing=false;
@@ -383,8 +397,15 @@ scrollSlider.addEventListener('input',()=>{scrollVolume=scrollSlider.value/10;})
 focusSlider.addEventListener('input',()=>{focusVolume=focusSlider.value/10;});
 selectSlider.addEventListener('input',()=>{selectVolume=selectSlider.value/10;});
 
+input.addEventListener('click',()=>hiddenInput.focus());
+hiddenInput.addEventListener('input',()=>{
+  inputText=hiddenInput.value;
+  updateInput();
+});
+
 function updateInput(){
   input.innerHTML='&gt; '+inputText+'<span class="cursor">█</span>';
+  hiddenInput.value=inputText;
 }
 updateInput();
 
@@ -647,16 +668,6 @@ document.addEventListener('keydown',e=>{
   if(e.key==='Tab'){
     e.preventDefault();
     if(!typing) goBack();
-    return;
-  }
-  if(typing) return;
-  if(e.key==='Backspace'){
-    inputText=inputText.slice(0,-1);
-    updateInput();
-    e.preventDefault();
-  }else if(e.key.length===1 && !e.ctrlKey && !e.metaKey){
-    inputText+=e.key;
-    updateInput();
   }
 });
 


### PR DESCRIPTION
## Summary
- add hidden input to capture text while keeping custom cursor display
- sync hidden input with terminal display and focus handling
- simplify keydown logic to rely on input events

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2809a84a08329a5032f9fb1c2ee86