### PR TITLE
Fix hidden input caret positioning for mobile typing

### DIFF
--- a/index.html
+++ b/index.html
@@ -406,6 +406,7 @@ hiddenInput.addEventListener('input',()=>{
 function updateInput(){
   input.innerHTML='&gt; '+inputText+'<span class="cursor">█</span>';
   hiddenInput.value=inputText;
+  hiddenInput.setSelectionRange(inputText.length,inputText.length);
 }
 updateInput();
 


### PR DESCRIPTION
## Summary
- Ensure the hidden input caret moves to the end after each update for proper mobile typing and backspace behavior.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node - <<'NODE' ...` (simulate typing and backspace)

------
https://chatgpt.com/codex/tasks/task_e_68b284c131d08329a11f0e4f769ec559