### PR TITLE
Keep terminal input visible and auto-scroll history

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,8 +179,9 @@
   }
   #content{
     flex:1;
-    overflow:hidden;
+    overflow-y:auto;
     word-break:break-word;
+    max-height:100%;
   }
   #input{
     white-space:pre-wrap;
@@ -193,6 +194,7 @@
     letter-spacing:inherit;
     line-height:inherit;
     caret-color:transparent;
+    flex-shrink:0;
   }
   #input::before{
     content:"> ";
@@ -361,6 +363,7 @@ const powerScreen=document.getElementById('power-screen');
 const header=document.getElementById('header');
 const content=document.getElementById('content');
 const input=document.getElementById('input');
+const historyEl=content;
 let currentOptions=[];
 let selected=-1;
 let typing=false;
@@ -524,6 +527,9 @@ async function typeText(el,text){
     if(delay>0) await sleep(delay);
   }
   el.textContent+='\n';
+  if(el.parentElement===historyEl){
+    historyEl.scrollTop=historyEl.scrollHeight;
+  }
 }
 
 function waitForContinue(){


### PR DESCRIPTION
## Summary
- allow terminal content to scroll within the screen and stay within terminal bounds
- keep input anchored at the bottom and auto-scroll history on new output

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b29465def483299182af582942a8c4