### PR TITLE
style: tighten hacking layout spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,14 +222,15 @@
     background:#008800;
     color:#041204;
   }
-  #hack-wrap{display:flex;justify-content:space-between;width:100%;}
+  #hack-wrap{display:flex;justify-content:flex-start;width:100%;gap:2ch;}
   #hacking{white-space:pre;font:inherit;flex-shrink:0;}
   #hacking .word{cursor:pointer;}
   #hacking .word:hover{background:#008800;color:#041204;}
-  #hack-messages{white-space:pre;margin-left:4ch;display:flex;flex-direction:column;justify-content:flex-end;align-items:flex-end;flex:1;}
+  #hack-messages{white-space:pre;display:flex;flex-direction:column;justify-content:flex-end;align-items:flex-end;flex:1;line-height:1;}
+  .hack-row{line-height:1;}
   #content.hack-content{display:flex;flex-direction:column;justify-content:flex-end;}
   #header.hack-header{padding-top:calc(4px * var(--scale));}
-  #header.hack-header #hack-title{margin-bottom:calc(16px * var(--scale));}
+  #header.hack-header #hack-title{margin-bottom:calc(8px * var(--scale));}
   #header.hack-header #hack-warning{margin-bottom:calc(4px * var(--scale));}
   #terminal.locked #content{opacity:0.2;}
   #lockout{position:absolute;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.9);display:flex;align-items:center;justify-content:center;text-align:center;white-space:pre-wrap;}


### PR DESCRIPTION
## Summary
- align hacking grid and message log using flex-start and gap
- tighten line spacing for hacking grid rows and message log
- reduce margin below hack title for a more compact header

## Testing
- `NODE_PATH=/tmp/puppeteer/node_modules node - <<'NODE'...` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b3259ddefc8329b7c3926787a254e2