### PR TITLE
Align input cursor to left

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,6 +193,7 @@
     line-height:inherit;
     caret-color:transparent;
     flex-shrink:0;
+    align-self:flex-start;
     overflow:hidden;
   }
   #input::before{


### PR DESCRIPTION
## Summary
- Align the hacking interface input line to the left so the cursor starts beside the prompt

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Terminal/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b36c346c888329be529e4aece08ed8