### PR TITLE
Align hack UI input to bottom-right

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,8 +230,8 @@
   #hacking .char.highlight{background:#008800;color:#041204;}
   #hacking .word:hover,
   #hacking .word.highlight{background:#008800;color:#041204;}
-  #hack-messages{white-space:pre;display:flex;flex-direction:column;justify-content:flex-end;align-items:flex-start;flex:1;line-height:1;align-self:flex-start;padding:0 calc(8px * var(--scale)) calc(24px * var(--scale)) 0;}
-  #hack-messages #input{margin-top:0;}
+  #hack-messages{white-space:pre;display:flex;flex-direction:column;justify-content:flex-end;align-items:flex-start;height:100%;flex:1;line-height:1;align-self:flex-start;padding:0 calc(8px * var(--scale)) calc(24px * var(--scale)) 0;}
+  #hack-messages #input{margin-top:0;align-self:flex-end;}
   .hack-message{text-align:left;}
   .hack-row{line-height:1;}
   #hacking, .hack-row { letter-spacing: inherit; }


### PR DESCRIPTION
## Summary
- Make `#hack-messages` a full-height column flexbox that bottom-justifies its children
- Align the hack input field to the right edge of the message container

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e879a6048329b8bed982bb80f92a