### PR TITLE
Move attempts indicator beneath password prompt

### DIFF
--- a/index.html
+++ b/index.html
@@ -232,7 +232,6 @@
   #hacking .word.highlight{background:#008800;color:#041204;}
   #hack-messages{white-space:pre;display:flex;flex-direction:column;justify-content:flex-end;align-items:flex-start;height:100%;flex:1;line-height:1;align-self:flex-start;padding:0 calc(8px * var(--scale)) calc(24px * var(--scale)) 0;}
   #hack-messages #input{margin-top:0;align-self:flex-start;}
-  #hack-messages #attempts{align-self:flex-start;margin-bottom:calc(2px * var(--scale));}
   #hack-prompt{margin-top:calc(4px * var(--scale));}
   .hack-message{text-align:left;}
   .hack-row{line-height:1;}
@@ -240,6 +239,7 @@
   #content.hack-content{display:flex;flex-direction:column;justify-content:flex-end;padding:calc(4px * var(--scale));padding-bottom:calc(22px * var(--scale));}
   #header.hack-header{padding-top:calc(16px * var(--scale));padding-bottom:calc(4px * var(--scale));}
   #header.hack-header #hack-title{margin-top:calc(4px * var(--scale));margin-bottom:calc(8px * var(--scale));}
+  #header.hack-header #attempts{margin-bottom:calc(4px * var(--scale));}
   #header.hack-header #hack-warning{margin-bottom:calc(4px * var(--scale));}
   #terminal.locked #content{opacity:0.2;}
   #lockout{position:absolute;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.9);display:flex;align-items:center;justify-content:center;text-align:center;white-space:pre-wrap;}
@@ -539,11 +539,12 @@ async function renderHackScreen(){
   prompt.id='hack-prompt';
   prompt.textContent='ENTER PASSWORD NOW';
   header.appendChild(prompt);
+  const attempts=document.createElement('div');
+  attempts.id='attempts';
+  header.appendChild(attempts);
   const warning=document.createElement('div');
   warning.id='hack-warning';
   header.appendChild(warning);
-  const attempts=document.createElement('div');
-  attempts.id='attempts';
   const wrap=document.createElement('div');
   wrap.id='hack-wrap';
   content.appendChild(wrap);
@@ -553,7 +554,6 @@ async function renderHackScreen(){
   const messages=document.createElement('div');
   messages.id='hack-messages';
   wrap.appendChild(messages);
-  messages.appendChild(attempts);
   messages.appendChild(input);
   startScrollSound();
   const rows=17,cols=12,total=rows*2;
@@ -674,7 +674,7 @@ function processGuess(guess){
     const ok=document.createElement('div');
     ok.textContent='Access granted.';
     box.appendChild(ok);
-    msg.insertBefore(box,hackingData.attemptsEl);
+    msg.insertBefore(box,input);
     hackingActive=false;
     hackingData.warningEl.textContent='';
     hackingData.attemptsEl.textContent='';
@@ -689,7 +689,7 @@ function processGuess(guess){
     const likeLine=document.createElement('div');
     likeLine.textContent=`${like}/${len} correct`;
     box.appendChild(likeLine);
-    msg.insertBefore(box,hackingData.attemptsEl);
+    msg.insertBefore(box,input);
     hackingData.attempts--;
     updateAttempts();
     playPasswordResult(false);


### PR DESCRIPTION
## Summary
- Place remaining-attempts display directly under the "Enter Password Now" prompt.
- Style the attempts line within the header for consistent spacing.
- Adjust message insertion to accommodate new attempts location.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f5bb4b888329941226c3098e9144