### PR TITLE
Reduce menu option highlight size

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,7 +217,7 @@
     width:100%;
     cursor:pointer;
     padding:0 calc(4px * var(--scale));
-    min-height:max(32px, calc(32px * var(--scale)));
+    min-height:max(24px, calc(24px * var(--scale)));
   }
   .option:hover, .option:focus, .option.selected{
     background:#008800;


### PR DESCRIPTION
## Summary
- Decrease menu option min-height to tighten selection highlight around text

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4026e379083298cbfa47b3605b6d6