### PR TITLE
Align menu intro text and refine highlight

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,7 +217,7 @@
     width:100%;
     cursor:pointer;
     padding:0 calc(4px * var(--scale));
-    min-height:max(24px, calc(24px * var(--scale)));
+    line-height:1;
   }
   .option:hover, .option:focus, .option.selected{
     background:#008800;
@@ -1022,6 +1022,8 @@ async function showIntro(){
   header.style.textAlign='center';
   for(const line of titleLines){
     const div=document.createElement('div');
+    div.style.textAlign='left';
+    div.style.marginLeft='2ch';
     header.appendChild(div);
     await typeText(div,line);
   }


### PR DESCRIPTION
## Summary
- Left-align intro title lines while keeping the header centered
- Shrink menu option highlight to match text height

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b403d77e04832982a7a80a003ee24f