### PR TITLE
Use solid line character in menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -298,7 +298,7 @@ const titleLines=[
 const headerLines=[
 "Welcome to the RobCo Engineering Division Database!",
 "How may I assist you this fine day?",
-"---------------------------------------",
+"───────────────────────────────────────",
 ];
 
 const screens={


### PR DESCRIPTION
## Summary
- replace hyphen divider with box-drawing character for a solid menu line

## Testing
- `npm test` (fails: package.json missing)
- `python -m pytest` (no tests discovered)


------
https://chatgpt.com/codex/tasks/task_e_68b40906995c8329968b35326559a1ca