### PR TITLE
Implement bracket pair mechanics for hacking minigame

### DIFF
--- a/index.html
+++ b/index.html
@@ -511,10 +511,17 @@ async function startHacking(){
     }
     if(pool.length<diff.wordCount[0]) throw new Error('Insufficient words');
     shuffle(pool);
-    const count=diff.wordCount[0]+Math.floor(Math.random()*(diff.wordCount[1]-diff.wordCount[0]+1));
-    const wordList=pool.slice(0,count);
-    const password=wordList[Math.floor(Math.random()*wordList.length)];
-    hackingData={attempts:4,password,wordList,difficulty:diff.name};
+      const count=diff.wordCount[0]+Math.floor(Math.random()*(diff.wordCount[1]-diff.wordCount[0]+1));
+      const wordList=pool.slice(0,count);
+      const password=wordList[Math.floor(Math.random()*wordList.length)];
+      hackingData={
+        attempts:4,
+        maxAttempts:4,
+        password,
+        wordList,
+        difficulty:diff.name,
+        activeWords:wordList.filter(w=>w!==password)
+      };
     await renderHackScreen();
   }catch(err){
     console.error('Failed to load words',err);
@@ -523,18 +530,59 @@ async function startHacking(){
   }
 }
 
+function detectBrackets(block){
+  const pairs=[];
+  const wordIndices=new Set();
+  for(const w of block.words){
+    const seg=w.segment||w.word;
+    for(let k=0;k<seg.length;k++){
+      wordIndices.add(w.start+k);
+    }
+  }
+  const match={'(':')','{':'}','[':']','<':'>'};
+  for(let i=0;i<block.chars.length;i++){
+    const ch=block.chars[i];
+    const close=match[ch];
+    if(!close) continue;
+    for(let j=i+1;j<block.chars.length;j++){
+      if(wordIndices.has(j)) break;
+      if(block.chars[j]===close){
+        pairs.push({start:i,end:j});
+        break;
+      }
+    }
+  }
+  block.brackets=pairs;
+}
+
 function blockHtml(block){
   const parts=[];
-  let last=0;
-  const wrapChars=arr=>arr.map(ch=>`<span class="char">${escapeHtml(ch)}</span>`).join('');
-  const words=block.words.slice().sort((a,b)=>a.start-b.start);
-  for(const w of words){
+  const regions=[];
+  for(const w of block.words){
     const seg=w.segment||w.word;
-    parts.push(wrapChars(block.chars.slice(last,w.start)));
-    parts.push(`<span class="word" data-word="${w.word}">${seg}</span>`);
-    last=w.start+seg.length;
+    regions.push({start:w.start,end:w.start+seg.length,type:'word',word:w.word,text:seg});
   }
-  parts.push(wrapChars(block.chars.slice(last)));
+  for(const b of block.brackets||[]){
+    regions.push({start:b.start,end:b.end+1,type:'bracket'});
+  }
+  regions.sort((a,b)=>a.start-b.start);
+  let idx=0;
+  const wrapChar=ch=>`<span class="char">${escapeHtml(ch)}</span>`;
+  for(const r of regions){
+    while(idx<r.start){
+      parts.push(wrapChar(block.chars[idx++]));
+    }
+    if(r.type==='word'){
+      parts.push(`<span class="word" data-word="${r.word}">${r.text}</span>`);
+    }else if(r.type==='bracket'){
+      const seg=block.chars.slice(r.start,r.end).map(wrapChar).join('');
+      parts.push(`<span class="bracket">${seg}</span>`);
+    }
+    idx=r.end;
+  }
+  while(idx<block.chars.length){
+    parts.push(wrapChar(block.chars[idx++]));
+  }
   return parts.join('');
 }
 
@@ -594,16 +642,17 @@ async function renderHackScreen(){
   await typeText(attempts,attemptsText);
   attempts.textContent=attempts.textContent.trimEnd();
   const rows=17,cols=12,total=rows*2;
-  const base=0xF000+Math.floor(Math.random()*(0xFFF-cols*total));
-  const chars='{}[]()<>/\\|;:!@#$%^&*-_=+,.?';
-  const blocks=[];
+    const base=0xF000+Math.floor(Math.random()*(0xFFF-cols*total));
+    const chars='{}[]()<>/\\|;:!@#$%^&*-_=+,.?';
+    hackingData.junkChars=chars;
+    const blocks=[];
   for(let i=0;i<total;i++){
     const arr=[];
     for(let j=0;j<cols;j++) arr.push(chars[Math.floor(Math.random()*chars.length)]);
     blocks.push({addr:(base+i*cols).toString(16).toUpperCase().padStart(4,'0'),chars:arr,words:[]});
   }
   const MAX_PLACEMENT_ATTEMPTS = 1000;
-  for(const word of hackingData.wordList){
+    for(const word of hackingData.wordList){
     const parts=[];
     for(let i=0;i<word.length;i+=cols) parts.push(word.slice(i,i+cols));
     const maxLen=parts.reduce((m,p)=>Math.max(m,p.length),0);
@@ -637,8 +686,9 @@ async function renderHackScreen(){
     if(!placed){
       console.warn('Failed to place word', word);
     }
-  }
-  let gridHtml='';
+    }
+    for(const block of blocks) detectBrackets(block);
+    let gridHtml='';
   for(let r=0;r<rows;r++){
     const left=blocks[r];
     const right=blocks[r+rows];
@@ -655,7 +705,7 @@ async function renderHackScreen(){
     });
     span.addEventListener('mouseleave',()=>span.classList.remove('highlight'));
   });
-  grid.querySelectorAll('.word').forEach(span=>{
+    grid.querySelectorAll('.word').forEach(span=>{
     span.addEventListener('mouseenter',()=>{
       grid.querySelectorAll(`.word[data-word="${span.dataset.word}"]`).forEach(w=>w.classList.add('highlight'));
       playWordFocusSound();
@@ -664,10 +714,14 @@ async function renderHackScreen(){
       grid.querySelectorAll(`.word[data-word="${span.dataset.word}"]`).forEach(w=>w.classList.remove('highlight'));
     });
     span.addEventListener('click',()=>processGuess(span.dataset.word));
-  });
-  hackingData.blocks=blocks;
-  hackingData.messages=messages;
-  input.focus();
+    });
+    grid.querySelectorAll('.bracket').forEach(span=>{
+      span.addEventListener('click',()=>useBracket(span));
+    });
+    hackingData.blocks=blocks;
+    hackingData.messages=messages;
+    hackingData.grid=grid;
+    input.focus();
 }
 
 function updateAttempts(){
@@ -737,6 +791,62 @@ function processGuess(guess){
   inputText='';
   updateInput();
   input.focus();
+}
+
+function addHackMessage(text){
+  const box=document.createElement('div');
+  box.className='hack-message';
+  const line=document.createElement('div');
+  line.textContent=text;
+  box.appendChild(line);
+  hackingData.messages.insertBefore(box,input);
+}
+
+function removeDud(){
+  const candidates=hackingData.activeWords.filter(w=>!hackingData.removedWords?.has(w));
+  if(!candidates.length) return;
+  const word=candidates[Math.floor(Math.random()*candidates.length)];
+  if(!hackingData.removedWords) hackingData.removedWords=new Set();
+  hackingData.removedWords.add(word);
+  hackingData.activeWords=hackingData.activeWords.filter(w=>w!==word);
+  const chars=hackingData.junkChars;
+  hackingData.grid.querySelectorAll(`.word[data-word="${word}"]`).forEach(span=>{
+    const len=span.textContent.length;
+    let junk='';
+    for(let i=0;i<len;i++) junk+=chars[Math.floor(Math.random()*chars.length)];
+    span.innerHTML=junk.split('').map(c=>`<span class="char">${escapeHtml(c)}</span>`).join('');
+    span.classList.remove('word');
+    span.removeAttribute('data-word');
+  });
+  addHackMessage('> Dud removed');
+}
+
+function resetAttempts(){
+  hackingData.attempts=hackingData.maxAttempts;
+  updateAttempts();
+  addHackMessage('> Allowance replenished');
+}
+
+function useBracket(span){
+  if(span.classList.contains('used')) return;
+  span.classList.add('used');
+  const len=span.textContent.length;
+  const chars=hackingData.junkChars;
+  let junk='';
+  for(let i=0;i<len;i++) junk+=chars[Math.floor(Math.random()*chars.length)];
+  const frag=document.createDocumentFragment();
+  for(const ch of junk){
+    const el=document.createElement('span');
+    el.className='char';
+    el.textContent=ch;
+    frag.appendChild(el);
+  }
+  span.replaceWith(frag);
+  if(Math.random()<0.5){
+    removeDud();
+  }else{
+    resetAttempts();
+  }
 }
 
 function displayMessage(text){


### PR DESCRIPTION
## Summary
- Detect bracket pairs across all types and stop scanning when any word characters intervene
- Clicking a bracket pair removes it and triggers either a dud removal or attempt reset

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4083f1634832988ebd65e68fad95b