### PR TITLE
Keep hacking guesses anchored to bottom

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,7 +236,7 @@
   #hacking .bracket{cursor:pointer;}
   #hacking .bracket:hover,
   #hacking .bracket.highlight{background:#008800;color:#041204;}
-  #hack-messages{white-space:pre;display:flex;flex-direction:column;justify-content:flex-start;align-items:flex-start;height:100%;flex:1;line-height:1;align-self:flex-start;padding:0 calc(8px * var(--scale)) calc(24px * var(--scale)) 0;}
+  #hack-messages{white-space:pre;display:flex;flex-direction:column;justify-content:flex-end;align-items:flex-start;height:100%;flex:1;line-height:1;align-self:flex-start;padding:0 calc(8px * var(--scale)) calc(24px * var(--scale)) 0;overflow:hidden;}
   #hack-messages #input{margin-top:0;align-self:flex-start;}
   #hack-prompt{margin-top:calc(4px * var(--scale));}
   .hack-message{text-align:left;}
@@ -763,11 +763,23 @@ function lockTerminal(){
   hackingData.attemptsEl.textContent='';
 }
 
+function trimHackMessages(){
+  const msg=hackingData.messages;
+  while(msg.scrollHeight>msg.clientHeight && msg.firstChild && msg.firstChild!==input){
+    msg.removeChild(msg.firstChild);
+  }
+}
+
+function insertHackBox(box){
+  const msg=hackingData.messages;
+  msg.insertBefore(box,input);
+  trimHackMessages();
+}
+
 function processGuess(guess){
   if(!hackingActive) return;
   guess=guess.trim().toUpperCase();
   const override=guess==='ADMIN OVERRIDE';
-  const msg=hackingData.messages;
   const len=hackingData.password.length;
   const box=document.createElement('div');
   box.className='hack-message';
@@ -782,7 +794,7 @@ function processGuess(guess){
     const ok=document.createElement('div');
     ok.textContent='Access granted.';
     box.appendChild(ok);
-    msg.insertBefore(box,input);
+    insertHackBox(box);
     hackingActive=false;
     hackingData.promptEl.textContent='';
     hackingData.warningEl.textContent='';
@@ -798,7 +810,7 @@ function processGuess(guess){
     const likeLine=document.createElement('div');
     likeLine.textContent=`${like}/${len} correct`;
     box.appendChild(likeLine);
-    msg.insertBefore(box,input);
+    insertHackBox(box);
     hackingData.attempts--;
     updateAttempts();
     playPasswordResult(false);
@@ -818,7 +830,7 @@ function addHackMessage(text){
   const line=document.createElement('div');
   line.textContent=text;
   box.appendChild(line);
-  hackingData.messages.insertBefore(box,input);
+  insertHackBox(box);
 }
 
 function removeDud(){


### PR DESCRIPTION
## Summary
- Anchor the hacking guess input at the bottom of the message column and push previous guesses upward.
- Trim old hacking guess entries when the message history exceeds the visible area.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4129a9a88832984d6f3512770ab3a