### PR TITLE
Slow lockout animation and preserve lockout after power cycle

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,7 +250,7 @@
   #header.hack-header #hack-title{margin-top:calc(4px * var(--scale));margin-bottom:calc(8px * var(--scale));}
   #header.hack-header #attempts{margin-bottom:calc(4px * var(--scale));}
     #header.hack-header #hack-warning{margin-bottom:calc(4px * var(--scale));}
-    #terminal-screen{height:100%;display:flex;flex-direction:column;transition:transform .5s linear;}
+    #terminal-screen{height:100%;display:flex;flex-direction:column;transition:transform 1s linear;}
     #terminal.locking #terminal-screen{transform:translateY(-100%);}
     #terminal.locked #content{opacity:0.2;}
   #lockout{position:absolute;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.9);display:flex;align-items:center;justify-content:center;text-align:center;white-space:pre-wrap;}
@@ -1314,18 +1314,19 @@ powerButton.addEventListener('click',async()=>{
     terminal.classList.add('powered');
     audioMenu.style.display='flex';
     startFanHum();
-    header.innerHTML='';
-    content.innerHTML='';
-    screenHistory=[];
-    currentOptions=[];
-    selected=-1;
-    inputText='';
-    input.textContent='';
-    updateInput();
-    hackingActive=false;
-    hackingData=null;
-    terminalLocked=false;
-    loadScrollSound().then(init);
+    if(!terminalLocked){
+      header.innerHTML='';
+      content.innerHTML='';
+      screenHistory=[];
+      currentOptions=[];
+      selected=-1;
+      inputText='';
+      input.textContent='';
+      updateInput();
+      hackingActive=false;
+      hackingData=null;
+      loadScrollSound().then(init);
+    }
     powered=true;
   }else{
     const powerSound=new Audio('Terminal 3/poweroff.mp3');
@@ -1338,7 +1339,6 @@ powerButton.addEventListener('click',async()=>{
     volumeControls.style.display='none';
     hackingActive=false;
     hackingData=null;
-    terminalLocked=false;
     powered=false;
   }
 });


### PR DESCRIPTION
## Summary
- Slow terminal lockout scroll animation by 50%
- Prevent powering on a locked terminal from reinitializing or generating text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b41cf6484c8329aa94dfb1b73cb8ac