### PR TITLE
Recognize syntaxhelper during hacking mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -914,22 +914,20 @@ function handleCommand(cmd){
     updateInput();
     return;
   }
-  if(hackingActive){
-    processGuess(cmd.trim().toUpperCase().slice(0,20));
-    return;
-  }
   const command=cmd.trim().toLowerCase();
-  if(command==='back'){
-    goBack();
-  }else if(command==='?'||command==='help'){
-    showScreen('help');
-  }else if(command==='syntaxhelper'){
+  if(command==='syntaxhelper'){
     if(hackingActive){
       hackingData.grid.querySelectorAll('.bracket').forEach(span=>span.classList.add('highlight'));
       setTimeout(()=>hackingData.grid.querySelectorAll('.bracket').forEach(span=>span.classList.remove('highlight')),1000);
     }else{
       displayMessage('command not recognized.');
     }
+  }else if(hackingActive){
+    processGuess(cmd.trim().toUpperCase().slice(0,20));
+  }else if(command==='back'){
+    goBack();
+  }else if(command==='?'||command==='help'){
+    showScreen('help');
   }else if(screens[command]){
     showScreen(command);
   }else{


### PR DESCRIPTION
## Summary
- Allow the `syntaxhelper` command to run even when hacking is active and highlight bracket pairs in that mode
- Fall back to "command not recognized" when not hacking

## Testing
- `node syntaxhelper_test.js`
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b41d11ef008329b6d56bae8a5ed7b6