### PR TITLE
Allow page scrolling on smaller screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,11 +15,11 @@
     --scale:1;
   }
   html{
-    overflow:hidden;
+    overflow:auto;
   }
   body{
     margin:0;
-    overflow:hidden;
+    overflow:auto;
     background:#000;
     color:#7aff7a;
     font-family:"FSEX300","IBM Plex Mono",ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Courier New",monospace;


### PR DESCRIPTION
## Summary
- enable page scroll on small displays by switching `html` and `body` overflow to `auto`

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b61f1b18348329a9cf9676f6875b79