### PR TITLE
Add terminal builder for configurable sessions

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Terminal Builder</title>
+<style>
+body{font-family:Arial,sans-serif;margin:20px;background:#111;color:#eee;}
+label{display:block;margin-top:10px;}
+textarea{width:100%;height:80px;}
+input[type=text]{width:100%;}
+button{margin-top:10px;}
+#preview{width:800px;height:600px;border:1px solid #333;margin-top:20px;}
+</style>
+</head>
+<body>
+<h1>Terminal Config Builder</h1>
+<form id="builder">
+  <label>Title Lines (one per line)
+    <textarea id="title"></textarea>
+  </label>
+  <label>Header Lines (one per line)
+    <textarea id="header"></textarea>
+  </label>
+  <label>Menu Entries (one per line)
+    <textarea id="menu"></textarea>
+  </label>
+  <label>Hacking Difficulty
+    <select id="difficulty">
+      <option>Very Easy</option>
+      <option>Easy</option>
+      <option>Average</option>
+      <option>Hard</option>
+      <option>Very Hard</option>
+    </select>
+  </label>
+  <label>Password
+    <input type="text" id="password" />
+  </label>
+  <label>Dud Words (one per line)
+    <textarea id="duds"></textarea>
+  </label>
+  <button type="submit">Generate</button>
+</form>
+<div id="downloads"></div>
+<iframe id="preview"></iframe>
+<script>
+function lines(id){
+  return document.getElementById(id).value.split('\n').map(l=>l.trim()).filter(Boolean);
+}
+function slug(text){
+  return text.toLowerCase().replace(/[^a-z0-9]+/g,'-');
+}
+function buildConfig(){
+  const titleLines=lines('title');
+  const headerLines=lines('header');
+  const menuLines=lines('menu');
+  const password=document.getElementById('password').value.trim();
+  const duds=lines('duds');
+  const difficulty=document.getElementById('difficulty').value;
+  const menu=menuLines.map(line=>({text:`> ${line}`,screen:slug(line)}));
+  const screens={menu};
+  menuLines.forEach(line=>{
+    const key=slug(line);
+    screens[key]=[`== ${line} ==`,"",{text:"> RETURN",screen:"menu"}];
+  });
+  return {
+    titleLines,
+    headerLines,
+    screens,
+    hacking:{difficulty,password,duds}
+  };
+}
+const form=document.getElementById('builder');
+form.addEventListener('submit',async e=>{
+  e.preventDefault();
+  const cfg=buildConfig();
+  const downloads=document.getElementById('downloads');
+  downloads.innerHTML='';
+  const jsonBlob=new Blob([JSON.stringify(cfg,null,2)],{type:'application/json'});
+  const jsonUrl=URL.createObjectURL(jsonBlob);
+  const jsonLink=document.createElement('a');
+  jsonLink.href=jsonUrl;
+  jsonLink.download='config.json';
+  jsonLink.textContent='Download config.json';
+  downloads.appendChild(jsonLink);
+  const base=await fetch('index.html').then(r=>r.text());
+  const replaced=base.replace('</body>',`<script>window.config=${JSON.stringify(cfg)};</script></body>`);
+  const htmlBlob=new Blob([replaced],{type:'text/html'});
+  const htmlUrl=URL.createObjectURL(htmlBlob);
+  const htmlLink=document.createElement('a');
+  htmlLink.href=htmlUrl;
+  htmlLink.download='index.html';
+  htmlLink.textContent='Download index.html';
+  downloads.appendChild(document.createElement('br'));
+  downloads.appendChild(htmlLink);
+  const iframe=document.getElementById('preview');
+  iframe.src=`index.html?config=${encodeURIComponent(jsonUrl)}`;
+});
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -299,19 +299,19 @@ function updateScale(){
 }
 window.addEventListener('resize',updateScale);
 updateScale();
-const titleLines=[
+let titleLines=[
 "ROBCO INDUSTRIES UNIFIED OPERATING SYSTEM",
 "COPYRIGHT 2075-2077 ROBCO INDUSTRIES",
 "-Server 12-",
 "",
 ];
-const headerLines=[
+let headerLines=[
 "Welcome to the RobCo Engineering Division Database!",
 "How may I assist you this fine day?",
 "───────────────────────────────────────",
 ];
 
-const screens={
+let screens={
   menu:[
     {text:"> Protectron Schematics",screen:"protectron"},
     {text:"> Mr. Handy Service Records",screen:"handy"},
@@ -402,6 +402,29 @@ const screens={
     {text:"> RETURN",screen:"menu"}
   ]
 };
+
+let hackingConfig=null;
+
+async function loadConfig(){
+  try{
+    const params=new URLSearchParams(location.search);
+    let cfg=null;
+    if(params.has('config')){
+      const res=await fetch(params.get('config'));
+      cfg=await res.json();
+    }else if(window.config){
+      cfg=window.config;
+    }
+    if(cfg){
+      if(cfg.titleLines) titleLines=cfg.titleLines;
+      if(cfg.headerLines) headerLines=cfg.headerLines;
+      if(cfg.screens) screens=cfg.screens;
+      if(cfg.hacking) hackingConfig=cfg.hacking;
+    }
+  }catch(err){
+    console.error('Failed to load config',err);
+  }
+}
 
 const terminal=document.getElementById('terminal');
 const terminalScreen=document.getElementById('terminal-screen');
@@ -497,43 +520,65 @@ function escapeHtml(str){
   return str.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
 }
 
-async function startHacking(){
+async function startHacking(custom){
   terminalLocked=false;
   hackingActive=true;
   try{
-    const res=await fetch('Hacking Words.txt');
-    const text=await res.text();
-    const all=(text.match(/[A-Za-z]+/g)||[]).map(w=>w.toUpperCase());
-    const byLen={};
-    for(const w of all){
-      const l=w.length;
-      (byLen[l]||(byLen[l]=new Set())).add(w);
-    }
-    const difficulties=[
-      {name:'Very Easy',wordCount:[8,10],length:[4,5]},
-      {name:'Easy',wordCount:[10,12],length:[6,7]},
-      {name:'Average',wordCount:[12,14],length:[8,9]},
-      {name:'Hard',wordCount:[15,17],length:[10,11]},
-      {name:'Very Hard',wordCount:[17,20],length:[12,15]}
-    ];
-    const diff=difficulties[Math.floor(Math.random()*difficulties.length)];
-    let pool=[];
-    for(let l=diff.length[0]; l<=diff.length[1]; l++){
-      if(byLen[l]) pool=pool.concat(Array.from(byLen[l]));
-    }
-    if(pool.length<diff.wordCount[0]) throw new Error('Insufficient words');
-    shuffle(pool);
-      const count=diff.wordCount[0]+Math.floor(Math.random()*(diff.wordCount[1]-diff.wordCount[0]+1));
-      const wordList=pool.slice(0,count);
-      const password=wordList[Math.floor(Math.random()*wordList.length)];
+    if(custom){
+      const password=(custom.password||'').toUpperCase();
+      const duds=(custom.duds||[]).map(w=>w.toUpperCase());
+      const wordList=[password,...duds];
+      const attemptsByDiff={
+        'Very Easy':4,
+        'Easy':4,
+        'Average':4,
+        'Hard':5,
+        'Very Hard':5
+      };
+      const attempts=attemptsByDiff[custom.difficulty]||4;
       hackingData={
-        attempts:4,
-        maxAttempts:4,
+        attempts,
+        maxAttempts:attempts,
         password,
         wordList,
-        difficulty:diff.name,
+        difficulty:custom.difficulty||'Custom',
         activeWords:wordList.filter(w=>w!==password)
       };
+    }else{
+      const res=await fetch('Hacking Words.txt');
+      const text=await res.text();
+      const all=(text.match(/[A-Za-z]+/g)||[]).map(w=>w.toUpperCase());
+      const byLen={};
+      for(const w of all){
+        const l=w.length;
+        (byLen[l]||(byLen[l]=new Set())).add(w);
+      }
+      const difficulties=[
+        {name:'Very Easy',wordCount:[8,10],length:[4,5]},
+        {name:'Easy',wordCount:[10,12],length:[6,7]},
+        {name:'Average',wordCount:[12,14],length:[8,9]},
+        {name:'Hard',wordCount:[15,17],length:[10,11]},
+        {name:'Very Hard',wordCount:[17,20],length:[12,15]}
+      ];
+      const diff=difficulties[Math.floor(Math.random()*difficulties.length)];
+      let pool=[];
+      for(let l=diff.length[0]; l<=diff.length[1]; l++){
+        if(byLen[l]) pool=pool.concat(Array.from(byLen[l]));
+      }
+      if(pool.length<diff.wordCount[0]) throw new Error('Insufficient words');
+      shuffle(pool);
+        const count=diff.wordCount[0]+Math.floor(Math.random()*(diff.wordCount[1]-diff.wordCount[0]+1));
+        const wordList=pool.slice(0,count);
+        const password=wordList[Math.floor(Math.random()*wordList.length)];
+        hackingData={
+          attempts:4,
+          maxAttempts:4,
+          password,
+          wordList,
+          difficulty:diff.name,
+          activeWords:wordList.filter(w=>w!==password)
+        };
+    }
     await renderHackScreen();
   }catch(err){
     console.error('Failed to load words',err);
@@ -1183,10 +1228,11 @@ document.addEventListener('click',e=>{
 },true);
 
 async function init(){
+  await loadConfig();
   startScrollSound();
   header.innerHTML='';
   stopScrollSound();
-  await startHacking();
+  await startHacking(hackingConfig);
 }
 
 async function showIntro(){


### PR DESCRIPTION
## Summary
- add builder.html to generate terminal configuration
- allow index.html to load external configs and custom hacking puzzle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b776b2c2e0832992c0a50527744264