### PR TITLE
feat: allow runtime config upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Terminal Configuration
+
+This project renders a retro terminal interface that reads its content from
+`config.json`. You can supply your own configuration file at runtime through the
+page itself.
+
+## Loading a custom configuration
+
+1. Open `index.html` in your browser.
+2. Use the **Config** file input beside the power button to select a JSON file
+   that matches the structure of `config.json`.
+3. Press the **Power** button to start the terminal. The uploaded configuration
+   will be used if provided; otherwise the default `config.json` is loaded.
+
+If you power off the terminal you can choose a different file and power on
+again to reload with the new configuration.
+

--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
     align-items:center;
     justify-content:flex-end;
   }
-  #power-container, #audio-menu{
+  #power-container, #audio-menu, #config-container{
     position:relative;
     display:flex;
     flex-direction:column;
@@ -87,6 +87,9 @@
   }
   #controls-container span{color:#7aff7a;}
   #audio-menu span{
+    margin-top:calc(5px * var(--scale));
+  }
+  #config-container span{
     margin-top:calc(5px * var(--scale));
   }
   #power-container span{
@@ -277,6 +280,10 @@
         <label>Select <input type="range" min="0" max="10" value="5" id="select-volume"></label>
       </div>
     </div>
+    <div id="config-container">
+      <input type="file" id="config-file" accept="application/json">
+      <span>Config</span>
+    </div>
     <div id="power-container">
       <button id="power-button" aria-label="Power">&#x23FB;</button>
       <span>Power</span>
@@ -304,14 +311,20 @@ let headerLines=[];
 let screens={};
 let hacking={};
 
-const configPromise=fetch('config.json')
-  .then(res=>res.json())
-  .then(cfg=>{
-    titleLines=cfg.titleLines;
-    headerLines=cfg.headerLines;
-    screens=cfg.screens;
-    hacking=cfg.hacking;
-  });
+let uploadedConfig=null;
+
+async function loadConfig(){
+  let cfg;
+  if(uploadedConfig){
+    cfg=uploadedConfig;
+  }else{
+    cfg=await fetch('config.json').then(res=>res.json());
+  }
+  titleLines=cfg.titleLines;
+  headerLines=cfg.headerLines;
+  screens=cfg.screens;
+  hacking=cfg.hacking;
+}
 
 const terminal=document.getElementById('terminal');
 const terminalScreen=document.getElementById('terminal-screen');
@@ -320,7 +333,21 @@ const powerScreen=document.getElementById('power-screen');
 const header=document.getElementById('header');
 const content=document.getElementById('content');
 const input=document.getElementById('input');
+const configFile=document.getElementById('config-file');
 const historyEl=content;
+
+configFile.addEventListener('change',async e=>{
+  const file=e.target.files[0];
+  if(file){
+    try{
+      const text=await file.text();
+      uploadedConfig=JSON.parse(text);
+    }catch(err){
+      console.error('Invalid configuration file',err);
+      uploadedConfig=null;
+    }
+  }
+});
 let currentOptions=[];
 let selected=-1;
 let typing=false;
@@ -1255,7 +1282,7 @@ powerButton.addEventListener('click',async()=>{
       updateInput();
       hackingActive=false;
       hackingData=null;
-      await configPromise;
+      await loadConfig();
       loadScrollSound().then(init);
     }
     powered=true;


### PR DESCRIPTION
## Summary
- add file input to load custom configuration JSON at runtime
- use uploaded config when available, otherwise fallback to default `config.json`
- document how to upload custom configuration

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b792e993a883298755b13c7183bbcf