### PR TITLE
feat: add locked setting and holotape button

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -29,6 +29,7 @@
   </fieldset>
   <fieldset>
     <legend>Hacking</legend>
+    <label><input type="checkbox" id="locked" checked> Locked</label>
     <label>Difficulty:
       <select id="difficulty">
         <option>Very Easy</option>
@@ -87,11 +88,13 @@ document.getElementById('builder-form').addEventListener('submit', e => {
   const difficulty = document.getElementById('difficulty').value;
   const password = document.getElementById('password').value.trim();
   const dudWords = document.getElementById('dud-words').value.split(',').map(s => s.trim()).filter(Boolean);
+  const locked = document.getElementById('locked').checked;
 
   const config = {
     titleLines: titles,
     headerLines: headers,
     screens: { menu: menuItems },
+    locked,
     hacking: {
       difficulty,
       password,

--- a/config.json
+++ b/config.json
@@ -101,6 +101,7 @@
       { "text": "> RETURN", "screen": "menu" }
     ]
   },
+  "locked": true,
   "hacking": {
     "difficulty": "Average",
     "password": "HARDWARE",

--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
     left:50%;
     transform:translateX(-50%);
   }
-  #power-button, #audio-toggle{
+  #power-button, #audio-toggle, #config-button{
     background:#b3410e;
     color:#fff;
     border:calc(2px * var(--scale)) solid #008800;
@@ -108,6 +108,10 @@
     font-size:calc(20px * var(--scale) * 0.9);
     cursor:pointer;
   }
+  #config-button{
+    background:#b8b20d;
+  }
+  #config-file{display:none;}
   #audio-menu{
     display:none;
     margin-bottom:calc(10px * var(--scale));
@@ -281,8 +285,9 @@
       </div>
     </div>
     <div id="config-container">
-      <input type="file" id="config-file" accept="application/json">
-      <span>Config</span>
+      <input type="file" id="config-file" accept="application/json" style="display:none">
+      <button id="config-button" aria-label="Holotape">&#x1F4FC;</button>
+      <span>Holotape</span>
     </div>
     <div id="power-container">
       <button id="power-button" aria-label="Power">&#x23FB;</button>
@@ -310,6 +315,7 @@ let titleLines=[];
 let headerLines=[];
 let screens={};
 let hacking={};
+let startLocked=true;
 
 let uploadedConfig=null;
 
@@ -324,6 +330,7 @@ async function loadConfig(){
   headerLines=cfg.headerLines;
   screens=cfg.screens;
   hacking=cfg.hacking;
+  startLocked=cfg.locked!==undefined?cfg.locked:true;
 }
 
 const terminal=document.getElementById('terminal');
@@ -334,6 +341,7 @@ const header=document.getElementById('header');
 const content=document.getElementById('content');
 const input=document.getElementById('input');
 const configFile=document.getElementById('config-file');
+const configButton=document.getElementById('config-button');
 const historyEl=content;
 
 configFile.addEventListener('change',async e=>{
@@ -348,6 +356,7 @@ configFile.addEventListener('change',async e=>{
     }
   }
 });
+configButton.addEventListener('click',()=>configFile.click());
 let currentOptions=[];
 let selected=-1;
 let typing=false;
@@ -1145,7 +1154,11 @@ async function init(){
   startScrollSound();
   header.innerHTML='';
   stopScrollSound();
-  await startHacking();
+  if(startLocked){
+    await startHacking();
+  }else{
+    await showIntro();
+  }
 }
 
 async function showIntro(){


### PR DESCRIPTION
## Summary
- add configurable `locked` flag in config and builder
- rename config control to Holotape with cassette button
- load locked setting to start unlocked or in hacking mode

## Testing
- `python -m json.tool config.json`


------
https://chatgpt.com/codex/tasks/task_e_68b796d0a5008329829ee857ba1db4e5