### PR TITLE
Add submenu and command-based menu actions

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -23,9 +23,9 @@
     <textarea id="headers" rows="4" cols="50" placeholder="Each line becomes a header line"></textarea>
   </fieldset>
   <fieldset>
-    <legend>Menu Items</legend>
-    <div id="menu-items"></div>
-    <button type="button" id="add-menu-item">Add Menu Item</button>
+    <legend>Screens</legend>
+    <div id="screens"></div>
+    <button type="button" id="add-screen">Add Screen</button>
   </fieldset>
   <fieldset>
     <legend>Hacking</legend>
@@ -55,36 +55,70 @@ const defaultDifficulties = [
   { name: "Very Hard", wordCount: [17,20], length: [12,15] }
 ];
 
-function addMenuItem(text='', screen='') {
+function addScreen(id='') {
+  const fs = document.createElement('fieldset');
+  fs.className = 'screen';
+  fs.innerHTML = '<legend>Screen</legend>' +
+                 '<label>ID: <input type="text" class="screen-id"></label>' +
+                 '<div class="menu-items"></div>' +
+                 '<button type="button" class="add-menu-item">Add Menu Item</button>' +
+                 '<button type="button" class="remove-screen">Remove Screen</button>';
+  fs.querySelector('.screen-id').value = id;
+  document.getElementById('screens').appendChild(fs);
+  addMenuItem(fs);
+}
+
+function addMenuItem(screenEl, text='', screen='', command='') {
   const div = document.createElement('div');
   div.className = 'menu-item';
   div.innerHTML = '<input type="text" class="menu-text" placeholder="Menu text">' +
                   '<input type="text" class="menu-screen" placeholder="Screen id">' +
+                  '<input type="text" class="menu-command" placeholder="Command message">' +
                   '<button type="button" class="remove-item">Remove</button>';
   div.querySelector('.menu-text').value = text;
   div.querySelector('.menu-screen').value = screen;
-  document.getElementById('menu-items').appendChild(div);
+  div.querySelector('.menu-command').value = command;
+  screenEl.querySelector('.menu-items').appendChild(div);
 }
 
-document.getElementById('add-menu-item').addEventListener('click', () => addMenuItem());
+document.getElementById('add-screen').addEventListener('click', () => addScreen());
 
-document.getElementById('menu-items').addEventListener('click', e => {
+document.getElementById('screens').addEventListener('click', e => {
   if (e.target.classList.contains('remove-item')) {
     e.target.parentElement.remove();
+  } else if (e.target.classList.contains('add-menu-item')) {
+    const screenEl = e.target.closest('.screen');
+    addMenuItem(screenEl);
+  } else if (e.target.classList.contains('remove-screen')) {
+    e.target.closest('.screen').remove();
   }
 });
 
-addMenuItem();
+addScreen('menu');
 
 document.getElementById('builder-form').addEventListener('submit', e => {
   e.preventDefault();
   const titles = document.getElementById('titles').value.split('\n').map(s => s.trim()).filter(Boolean);
   const headers = document.getElementById('headers').value.split('\n').map(s => s.trim()).filter(Boolean);
-  const menuItems = Array.from(document.querySelectorAll('#menu-items .menu-item')).map(item => {
-    const text = item.querySelector('.menu-text').value.trim();
-    const screen = item.querySelector('.menu-screen').value.trim();
-    return text && screen ? { text, screen } : null;
-  }).filter(Boolean);
+  const screensObj = {};
+  Array.from(document.querySelectorAll('#screens .screen')).forEach(screenEl => {
+    const id = screenEl.querySelector('.screen-id').value.trim();
+    if(!id) return;
+    const items = Array.from(screenEl.querySelectorAll('.menu-item')).map(item => {
+      const text = item.querySelector('.menu-text').value.trim();
+      const screen = item.querySelector('.menu-screen').value.trim();
+      const command = item.querySelector('.menu-command').value.trim();
+      if(!text && !screen && !command) return null;
+      if(screen){
+        return { text, screen };
+      }else if(command){
+        return { text, command };
+      }else{
+        return text;
+      }
+    }).filter(x => x !== null);
+    screensObj[id] = items;
+  });
   const difficulty = document.getElementById('difficulty').value;
   const password = document.getElementById('password').value.trim();
   const dudWords = document.getElementById('dud-words').value.split(',').map(s => s.trim()).filter(Boolean);
@@ -93,7 +127,7 @@ document.getElementById('builder-form').addEventListener('submit', e => {
   const config = {
     titleLines: titles,
     headerLines: headers,
-    screens: { menu: menuItems },
+    screens: screensObj,
     locked,
     hacking: {
       difficulty,

--- a/config.json
+++ b/config.json
@@ -16,6 +16,8 @@
       { "text": "> Mr. Handy Service Records", "screen": "handy" },
       { "text": "> Assaultron Combat Models", "screen": "assaultron" },
       { "text": "> Securitron Systems Control", "screen": "securitron" },
+      { "text": "> Turret Controls", "screen": "turret" },
+      { "text": "> Run Protectron Maintenance Mode", "command": "Maintenance mode Engaged" },
       { "text": "> Experimental Robotics Files", "screen": "experimental" },
       "",
       ""
@@ -73,6 +75,14 @@
       "",
       "Systems stable. Last crash report: NONE.",
       "All Securitron units in storage. Awaiting deployment order.",
+      "",
+      { "text": "> RETURN", "screen": "menu" }
+    ],
+    "turret": [
+      "== TURRET CONTROLS ==",
+      "",
+      { "text": "> Activate Turrets", "command": "Live fire mode engaged" },
+      { "text": "> Deactivate Turrets", "command": "Turrets placed in standby mode" },
       "",
       { "text": "> RETURN", "screen": "menu" }
     ],

--- a/index.html
+++ b/index.html
@@ -1210,7 +1210,14 @@ async function showScreen(name){
         div.className='option';
         div.tabIndex=0;
         await typeText(div,line.text);
-        div.addEventListener('click',()=>{playSelectSound();showScreen(line.screen);});
+        div.addEventListener('click',()=>{
+          playSelectSound();
+          if(line.screen){
+            showScreen(line.screen);
+          }else if(line.command){
+            displayMessage(line.command);
+          }
+        });
         div.addEventListener('mouseenter',()=>{
           if(selected>=0){
             currentOptions[selected].classList.remove('selected');


### PR DESCRIPTION
## Summary
- allow menu items to trigger command responses in the terminal
- extend builder to configure command-based menu items
- add turret control submenu with activate/deactivate options and maintenance command example
- allow builder to create nested screens for submenus

## Testing
- `python -m json.tool config.json`


------
https://chatgpt.com/codex/tasks/task_e_68b7a5774ad08329a7e7e2c1626993f6