### PR TITLE
Fix command feedback and add enter sound

### DIFF
--- a/index.html
+++ b/index.html
@@ -748,7 +748,7 @@ function insertHackBox(box){
   trimHackMessages();
 }
 
-function processGuess(guess){
+function processGuess(guess,playSound=true){
   if(!hackingActive) return;
   guess=guess.trim().toUpperCase();
   const override=guess==='ADMIN OVERRIDE';
@@ -759,7 +759,7 @@ function processGuess(guess){
   const guessLine=document.createElement('div');
   guessLine.textContent=`>${override?'ADMIN OVERRIDE':allowances?'ADMIN ALLOWANCES':guess}`;
   box.appendChild(guessLine);
-  playEnterCharSound();
+  if(playSound) playEnterCharSound();
   if(allowances){
     hackingData.attempts=99;
     hackingData.maxAttempts=99;
@@ -865,7 +865,9 @@ function displayMessage(text){
   const div=document.createElement('div');
   div.className='response';
   div.textContent=text;
-  terminal.insertBefore(div,input);
+  if(input.parentElement){
+    input.parentElement.insertBefore(div,input);
+  }
   setTimeout(()=>div.classList.add('fade'),5000);
   setTimeout(()=>div.remove(),6000);
 }
@@ -875,6 +877,7 @@ function clearResponses(){
 }
 
 function handleCommand(cmd){
+  playEnterCharSound();
   clearResponses();
   if(terminalLocked){
     input.textContent='';
@@ -888,10 +891,10 @@ function handleCommand(cmd){
       hackingData.grid.querySelectorAll('.bracket').forEach(span=>span.classList.add('highlight'));
       setTimeout(()=>hackingData.grid.querySelectorAll('.bracket').forEach(span=>span.classList.remove('highlight')),1000);
     }else{
-      displayMessage('command not recognized.');
+      displayMessage('command unknown');
     }
   }else if(hackingActive){
-    processGuess(cmd.trim().toUpperCase().slice(0,20));
+    processGuess(cmd.trim().toUpperCase().slice(0,20),false);
   }else if(command==='back'){
     goBack();
   }else if(command==='?'||command==='help'){
@@ -899,7 +902,7 @@ function handleCommand(cmd){
   }else if(screens[command]){
     showScreen(command);
   }else{
-    displayMessage('command not recognized.');
+    displayMessage('command unknown');
   }
   input.textContent='';
   inputText='';


### PR DESCRIPTION
## Summary
- show command feedback above the input
- play random enter sound on command submit
- report unknown commands with consistent text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b2088aac8329bdaa31f217f34e95