### PR TITLE
Add boot animation after successful hack

### DIFF
--- a/index.html
+++ b/index.html
@@ -424,6 +424,8 @@ const MAX_INPUT_CHARS=64;
 let hackingActive=false;
 let hackingData=null;
 let terminalLocked=false;
+let hackedOnce=false;
+let hackedPasswordLength=0;
 
 function restoreInput(){
   if(input.parentElement!==terminalScreen){
@@ -808,6 +810,8 @@ function processGuess(guess){
     ok.textContent='Access granted.';
     box.appendChild(ok);
     insertHackBox(box);
+    hackedOnce=true;
+    hackedPasswordLength=len;
     hackingActive=false;
     hackingData.promptEl.textContent='';
     hackingData.warningEl.textContent='';
@@ -1111,6 +1115,16 @@ async function typeText(el,text){
   }
 }
 
+async function typeWithCharSound(el,text){
+  const delay=baseDelay*2;
+  for(const ch of text){
+    el.textContent+=ch;
+    playCharFocusSound();
+    await sleep(delay);
+  }
+  el.textContent+='\n';
+}
+
 function splitEntities(str){
   const div=document.createElement('div');
   div.textContent=str;
@@ -1187,6 +1201,35 @@ async function init(){
   header.innerHTML='';
   stopScrollSound();
   await startHacking();
+}
+
+async function bootAnimation(){
+  restoreInput();
+  header.innerHTML='';
+  content.innerHTML='';
+  header.classList.remove('hack-header');
+  content.classList.remove('hack-content');
+  header.style.marginLeft='-2ch';
+  header.style.textAlign='left';
+  const welcome=document.createElement('div');
+  content.appendChild(welcome);
+  startScrollSound();
+  await typeText(welcome,'Welcome to RobCo Industries (TM) Termlink');
+  stopScrollSound();
+  const logon=document.createElement('div');
+  logon.textContent='>';
+  content.appendChild(logon);
+  await typeWithCharSound(logon,'Logon Admin');
+  const enter=document.createElement('div');
+  content.appendChild(enter);
+  startScrollSound();
+  await typeText(enter,'Enter Password');
+  stopScrollSound();
+  const pw=document.createElement('div');
+  pw.textContent='>';
+  content.appendChild(pw);
+  await typeWithCharSound(pw,'*'.repeat(hackedPasswordLength));
+  await showIntro();
 }
 
 async function showIntro(){
@@ -1323,7 +1366,8 @@ powerButton.addEventListener('click',async()=>{
       updateInput();
       hackingActive=false;
       hackingData=null;
-      loadScrollSound().then(init);
+      const startFn=hackedOnce?bootAnimation:init;
+      loadScrollSound().then(startFn);
     }
     powered=true;
   }else{


### PR DESCRIPTION
## Summary
- track when a terminal has been previously hacked and store password length
- introduce boot animation that plays on power up if already hacked, typing login and masked password with audio effects
- invoke boot animation instead of hacking sequence for subsequent power-ons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b756d0348329ab9c8ddcaf842667