### PR TITLE
Preserve leading whitespace in menu items

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -106,10 +106,9 @@ document.getElementById('builder-form').addEventListener('submit', e => {
     if(!id) return;
     const items = Array.from(screenEl.querySelectorAll('.menu-item')).map(item => {
       const textEl = item.querySelector('.menu-text');
-      const text = textEl.value;
+      const text = textEl.value.trimEnd();
       const screen = item.querySelector('.menu-screen').value.trim();
       const command = item.querySelector('.menu-command').value.trim();
-      if(!text.trim() && !screen && !command) return null;
       if(screen){
         return { text, screen };
       }else if(command){
@@ -117,7 +116,7 @@ document.getElementById('builder-form').addEventListener('submit', e => {
       }else{
         return text;
       }
-    }).filter(x => x !== null);
+    });
     screensObj[id] = items;
   });
   const difficulty = document.getElementById('difficulty').value;


### PR DESCRIPTION
## Summary
- Use `trimEnd()` on menu item text to keep leading spaces
- Retain menu entries with empty text so blank lines are preserved

## Testing
- `node -e "const items=[{text:'  option1  ',screen:''},{text:'   ',screen:''},{text:'',screen:''}];const processed=items.map(item=>{const text=item.text.trimEnd();const screen=(item.screen||'').trim();const command=(item.command||'').trim();if(screen){return{ text, screen };}else if(command){return{ text, command };}else{return text;}});const config={screens:{menu:processed}};console.log(JSON.stringify(config,null,2));"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7bfffb8e483299259724d2b609dad