### PR TITLE
Preserve line breaks in Terminal options

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,6 +225,7 @@
     cursor:pointer;
     padding:0 calc(4px * var(--scale));
     line-height:1;
+    white-space:pre-wrap;
   }
   .option + .option{
     margin-top:calc(4px * var(--scale));


### PR DESCRIPTION
## Summary
- ensure terminal menu option text respects newlines by using `white-space: pre-wrap`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node - <<'NODE' ...` (jsdom check for pre-wrap handling)


------
https://chatgpt.com/codex/tasks/task_e_68b7c00d59108329b2f0f03c3098f9d5