### PR TITLE
Support empty lines and blank menu text in config builder

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -98,8 +98,8 @@ addScreen('menu');
 
 document.getElementById('builder-form').addEventListener('submit', e => {
   e.preventDefault();
-  const titles = document.getElementById('titles').value.split('\n').map(s => s.trim()).filter(Boolean);
-  const headers = document.getElementById('headers').value.split('\n').map(s => s.trim()).filter(Boolean);
+  const titles = document.getElementById('titles').value.split('\n');
+  const headers = document.getElementById('headers').value.split('\n');
   const screensObj = {};
   Array.from(document.querySelectorAll('#screens .screen')).forEach(screenEl => {
     const id = screenEl.querySelector('.screen-id').value.trim();
@@ -109,7 +109,7 @@ document.getElementById('builder-form').addEventListener('submit', e => {
       const text = textEl.value;
       const screen = item.querySelector('.menu-screen').value.trim();
       const command = item.querySelector('.menu-command').value.trim();
-      if(!text.trim() && !screen && !command) return null;
+      if(text === '' && !screen && !command) return null;
       if(screen){
         return { text, screen };
       }else if(command){

--- a/builder.html
+++ b/builder.html
@@ -98,8 +98,8 @@ addScreen('menu');
 
 document.getElementById('builder-form').addEventListener('submit', e => {
   e.preventDefault();
-  const titles = document.getElementById('titles').value.split('\n');
-  const headers = document.getElementById('headers').value.split('\n');
+  const titles = document.getElementById('titles').value.split(/\r?\n/);
+  const headers = document.getElementById('headers').value.split(/\r?\n/);
   const screensObj = {};
   Array.from(document.querySelectorAll('#screens .screen')).forEach(screenEl => {
     const id = screenEl.querySelector('.screen-id').value.trim();

--- a/builder.html
+++ b/builder.html
@@ -98,8 +98,9 @@ addScreen('menu');
 
 document.getElementById('builder-form').addEventListener('submit', e => {
   e.preventDefault();
-  const titles = document.getElementById('titles').value.split(/\r?\n/);
-  const headers = document.getElementById('headers').value.split(/\r?\n/);
+    // Split on CRLF or LF without trimming to preserve explicit blank lines
+    const titles = document.getElementById('titles').value.split(/\r\n|\n/);
+    const headers = document.getElementById('headers').value.split(/\r\n|\n/);
   const screensObj = {};
   Array.from(document.querySelectorAll('#screens .screen')).forEach(screenEl => {
     const id = screenEl.querySelector('.screen-id').value.trim();


### PR DESCRIPTION
## Summary
- preserve blank lines in titles and headers by removing trimming and filtering
- keep menu items with empty text unless all fields are empty

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c0a0c0c48329b8b6e5162c4a73f9