### PR TITLE
feat: allow optional scale config

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -137,13 +137,20 @@ document.getElementById('builder-form').addEventListener('submit', e => {
   const locked = document.getElementById('locked').checked;
   const textColor = document.getElementById('text-color').value;
   const backgroundColor = document.getElementById('bg-color').value;
-  const scale = parseFloat(document.getElementById('scale').value) || 1;
+  const scaleInput = document.getElementById('scale').value.trim();
+  const style = { textColor, backgroundColor };
+  if (scaleInput !== '') {
+    const scale = parseFloat(scaleInput);
+    if (!isNaN(scale) && scale !== 1) {
+      style.scale = scale;
+    }
+  }
 
   const config = {
     titleLines: titles,
     headerLines: headers,
     screens: screensObj,
-    style: { textColor, backgroundColor, scale },
+    style,
     locked,
     hacking: {
       difficulty,

--- a/index.html
+++ b/index.html
@@ -334,10 +334,10 @@ async function loadConfig(){
   screens=cfg.screens;
   hacking=cfg.hacking;
   if(cfg.style){
-    const {textColor, backgroundColor, scale}=cfg.style;
+    const {textColor, backgroundColor}=cfg.style;
     if(textColor) document.documentElement.style.setProperty('--text-color', textColor);
     if(backgroundColor) document.documentElement.style.setProperty('--terminal-bg', backgroundColor);
-    if(scale) document.documentElement.style.setProperty('--scale', scale);
+    if('scale' in cfg.style) document.documentElement.style.setProperty('--scale', cfg.style.scale);
   }
   startLocked=cfg.locked!==undefined?cfg.locked:true;
   if(hasHacked) startLocked=false;


### PR DESCRIPTION
## Summary
- Only include `style.scale` in generated configs when the user enters a non-default value
- Apply `style.scale` during config load only if the property exists

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c754d7508329b2b4117bc87dd976