### PR TITLE
Remove manual scale option

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -31,7 +31,6 @@
     <legend>Style</legend>
     <label title="Color of text displayed in the terminal.">Text Color: <input type="color" id="text-color" value="#7aff7a"></label>
     <label title="Background color of the terminal window.">Background Color: <input type="color" id="bg-color" value="#041204"></label>
-    <label title="Overall scale factor for the terminal UI.">Scale: <input type="number" id="scale" value="1" step="0.1"></label>
   </fieldset>
   <fieldset title="Configure hacking settings for locked terminals.">
     <legend>Hacking</legend>
@@ -137,14 +136,7 @@ document.getElementById('builder-form').addEventListener('submit', e => {
   const locked = document.getElementById('locked').checked;
   const textColor = document.getElementById('text-color').value;
   const backgroundColor = document.getElementById('bg-color').value;
-  const scaleInput = document.getElementById('scale').value.trim();
   const style = { textColor, backgroundColor };
-  if (scaleInput !== '') {
-    const scale = parseFloat(scaleInput);
-    if (!isNaN(scale) && scale !== 1) {
-      style.scale = scale;
-    }
-  }
 
   const config = {
     titleLines: titles,

--- a/config.json
+++ b/config.json
@@ -113,8 +113,7 @@
   },
   "style": {
     "textColor": "#7aff7a",
-    "backgroundColor": "#041204",
-    "scale": 1
+    "backgroundColor": "#041204"
   },
   "locked": true,
   "hacking": {

--- a/index.html
+++ b/index.html
@@ -343,12 +343,11 @@ async function loadConfig(){
   headerLines=cfg.headerLines;
   screens=cfg.screens;
   hacking=cfg.hacking;
-  if(cfg.style){
-    const {textColor, backgroundColor}=cfg.style;
-    if(textColor) document.documentElement.style.setProperty('--text-color', textColor);
-    if(backgroundColor) document.documentElement.style.setProperty('--terminal-bg', backgroundColor);
-    if('scale' in cfg.style) document.documentElement.style.setProperty('--scale', cfg.style.scale);
-  }
+    if(cfg.style){
+      const {textColor, backgroundColor}=cfg.style;
+      if(textColor) document.documentElement.style.setProperty('--text-color', textColor);
+      if(backgroundColor) document.documentElement.style.setProperty('--terminal-bg', backgroundColor);
+    }
   startLocked=cfg.locked!==undefined?cfg.locked:true;
   if(hasHacked) startLocked=false;
 }


### PR DESCRIPTION
## Summary
- Drop manual scale control from the config builder UI
- Stop exporting a `scale` value in generated configs and default config.json
- Ignore `style.scale` in runtime; rely solely on automatic sizing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d2f41e588329a699458724f500e1