### PR TITLE
feat: load config and tooltip icons

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -9,10 +9,16 @@
     .menu-item { margin-bottom: 0.5rem; }
     .menu-item input, .menu-item textarea { margin-right: 0.5rem; }
     iframe { width: 100%; height: 600px; border: 1px solid #ccc; margin-top: 1rem; }
+    .tooltip-wrapper { position: relative; display: inline-block; }
+    .tooltip-icon { margin-left: 0.25rem; cursor: help; background: #ccc; border-radius: 50%; width: 1em; height: 1em; display: inline-flex; align-items: center; justify-content: center; font-size: 0.8em; }
+    .tooltip-text { visibility: hidden; background-color: #333; color: #fff; border-radius: 4px; padding: 0.5em; position: absolute; z-index: 1; bottom: 125%; left: 50%; transform: translateX(-50%); width: 200px; }
+    .tooltip-wrapper:hover .tooltip-text { visibility: visible; }
   </style>
 </head>
 <body>
 <h1>Config Builder</h1>
+<button type="button" id="load-config" title="Load configuration from JSON">Load Config</button>
+<input type="file" id="config-file" accept="application/json" style="display:none">
 <form id="builder-form">
   <fieldset title="Enter the lines displayed at the top of the terminal. Each line becomes a separate title line.">
     <legend>Titles</legend>
@@ -61,6 +67,32 @@ const defaultDifficulties = [
   { name: "Very Hard", wordCount: [17,20], length: [12,15] }
 ];
 
+function createTooltip(el) {
+  const text = el.getAttribute('title');
+  if (!text) return;
+  el.removeAttribute('title');
+  const wrapper = document.createElement('span');
+  wrapper.className = 'tooltip-wrapper';
+  const icon = document.createElement('span');
+  icon.className = 'tooltip-icon';
+  icon.textContent = '?';
+  const tip = document.createElement('span');
+  tip.className = 'tooltip-text';
+  tip.textContent = text;
+  wrapper.appendChild(icon);
+  wrapper.appendChild(tip);
+  if (el.tagName === 'FIELDSET') {
+    const legend = el.querySelector('legend');
+    legend.appendChild(wrapper);
+  } else {
+    el.parentNode.insertBefore(wrapper, el.nextSibling);
+  }
+}
+
+function applyTooltipsWithin(root) {
+  root.querySelectorAll('[title]').forEach(el => createTooltip(el));
+}
+
 function addScreen(id='') {
   const fs = document.createElement('fieldset');
   fs.className = 'screen';
@@ -72,6 +104,7 @@ function addScreen(id='') {
   fs.querySelector('.screen-id').value = id;
   document.getElementById('screens').appendChild(fs);
   addMenuItem(fs);
+  applyTooltipsWithin(fs);
 }
 
 function addMenuItem(screenEl, text='', screen='', command='') {
@@ -85,6 +118,39 @@ function addMenuItem(screenEl, text='', screen='', command='') {
   div.querySelector('.menu-screen').value = screen;
   div.querySelector('.menu-command').value = command;
   screenEl.querySelector('.menu-items').appendChild(div);
+  applyTooltipsWithin(div);
+}
+
+function loadConfig(config) {
+  document.getElementById('titles').value = (config.titleLines || []).join('\n');
+  document.getElementById('headers').value = (config.headerLines || []).join('\n');
+
+  const screensDiv = document.getElementById('screens');
+  screensDiv.innerHTML = '';
+  Object.entries(config.screens || {}).forEach(([id, items]) => {
+    addScreen(id);
+    const screenEl = screensDiv.lastElementChild;
+    screenEl.querySelector('.menu-items').innerHTML = '';
+    items.forEach(item => {
+      if (typeof item === 'string') {
+        addMenuItem(screenEl, item);
+      } else if (item.screen) {
+        addMenuItem(screenEl, item.text || '', item.screen);
+      } else if (item.command) {
+        addMenuItem(screenEl, item.text || '', '', item.command);
+      }
+    });
+  });
+
+  const style = config.style || {};
+  document.getElementById('text-color').value = style.textColor || '#7aff7a';
+  document.getElementById('bg-color').value = style.backgroundColor || '#041204';
+  document.getElementById('border-color').value = style.borderColor || '#008800';
+
+  document.getElementById('locked').checked = config.locked || false;
+  document.getElementById('difficulty').value = config.hacking?.difficulty || 'Average';
+  document.getElementById('password').value = config.hacking?.password || '';
+  document.getElementById('dud-words').value = (config.hacking?.dudWords || []).join(', ');
 }
 
 document.getElementById('add-screen').addEventListener('click', () => addScreen());
@@ -100,7 +166,22 @@ document.getElementById('screens').addEventListener('click', e => {
   }
 });
 
+document.getElementById('load-config').addEventListener('click', () => document.getElementById('config-file').click());
+
+document.getElementById('config-file').addEventListener('change', e => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = () => {
+    const config = JSON.parse(reader.result);
+    loadConfig(config);
+    updatePreview(config);
+  };
+  reader.readAsText(file);
+});
+
 addScreen('menu');
+applyTooltipsWithin(document);
 
 document.getElementById('builder-form').addEventListener('submit', e => {
   e.preventDefault();


### PR DESCRIPTION
## Summary
- allow importing an existing `config.json` into the builder
- replace title-based tooltips with small `?` icons for clarity

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7dbaa88b88329b31cbc88650a07a7