### PR TITLE
Gate input autofocusing on touch devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -361,6 +361,8 @@ const powerScreen=document.getElementById('power-screen');
 const header=document.getElementById('header');
 const content=document.getElementById('content');
 const input=document.getElementById('input');
+const isTouch=('ontouchstart' in window || navigator.maxTouchPoints>0 || window.matchMedia('(pointer: coarse)').matches);
+function focusInput(){if(!isTouch) input.focus();}
 const configFile=document.getElementById('config-file');
 const configButton=document.getElementById('config-button');
 const historyEl=content;
@@ -731,7 +733,7 @@ async function renderHackScreen(){
   hackingData.blocks=blocks;
   hackingData.messages=messages;
   hackingData.grid=grid;
-  input.focus();
+  focusInput();
 }
 
 function updateAttempts(){
@@ -827,7 +829,7 @@ function processGuess(guess,playSound=true){
   input.textContent='';
   inputText='';
   updateInput();
-  input.focus();
+  focusInput();
 }
 
 function addHackMessage(text){
@@ -932,7 +934,7 @@ function handleCommand(cmd){
   input.textContent='';
   inputText='';
   updateInput();
-  input.focus();
+  focusInput();
 }
 
 const audioCtx=new (window.AudioContext||window.webkitAudioContext)();


### PR DESCRIPTION
## Summary
- Detect touch devices and skip focusing the terminal input automatically
- Replace direct `input.focus()` calls with `focusInput()` that only runs on non-touch devices

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7dab78dd483298f29a06ef04cb647