### PR TITLE
Add spacing to boot sequence animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1232,18 +1232,24 @@ async function showLockedBoot(){
   await typeText(l1,'WELCOME TO ROBCO INDUSTRIES (TM) TERMLINK');
   stopScrollSound();
 
+  const br0=document.createElement('br');
+  header.appendChild(br0);
+
   const l2=document.createElement('div');
   l2.textContent='>';
   header.appendChild(l2);
   if(speed!==Infinity) await sleep(1500);
   await typeUserInput(l2,'SET TERMINAL/INQUIRE');
-  const br1=document.createElement('div');
+  const br1=document.createElement('br');
   header.appendChild(br1);
   startScrollSound();
   const l3=document.createElement('div');
   header.appendChild(l3);
   await typeText(l3,'RIT-V300');
   stopScrollSound();
+
+  const br2=document.createElement('br');
+  header.appendChild(br2);
 
   const l4=document.createElement('div');
   l4.textContent='>';
@@ -1256,8 +1262,8 @@ async function showLockedBoot(){
   header.appendChild(l5);
   if(speed!==Infinity) await sleep(1500);
   await typeUserInput(l5,'SET HALT RESTART/MAINT');
-  const br2=document.createElement('div');
-  header.appendChild(br2);
+  const br3=document.createElement('br');
+  header.appendChild(br3);
   startScrollSound();
   for(const text of bootLines){
     const div=document.createElement('div');
@@ -1265,6 +1271,9 @@ async function showLockedBoot(){
     await typeText(div,text);
   }
   stopScrollSound();
+
+  const br4=document.createElement('br');
+  header.appendChild(br4);
 
   const lEnd=document.createElement('div');
   lEnd.textContent='>';
@@ -1295,7 +1304,7 @@ async function showBoot(){
   header.appendChild(line2);
   if(speed!==Infinity) await sleep(1500);
   await typeUserInput(line2,'Logon Admin');
-  const brBoot=document.createElement('div');
+  const brBoot=document.createElement('br');
   header.appendChild(brBoot);
   const line3=document.createElement('div');
   header.appendChild(line3);


### PR DESCRIPTION
## Summary
- replace placeholder divs with `<br>` elements so boot sequence spacing isn't trimmed
- use break element in login prompt for consistent blank line

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ef53cf348329a14a9ca304e44d7f