### PR TITLE
Document optional passwords and dud words in terminal config

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,36 @@ page itself.
 If you power off the terminal you can choose a different file and power on
 again to reload with the new configuration.
 
+
+## Optional Passwords and Dud Words
+
+The hacking mini-game can be customized by providing a `password` and optional
+`dudWords` in the `hacking` section of the configuration. This allows you to
+control exactly which words appear during the puzzle.
+
+- If you supply more candidate words than the selected difficulty requires, only
+  your words are used.
+- If you only provide `dudWords` and omit `password`, one of the provided
+  words is selected as the password and the rest remain duds. Any additional
+  slots are backfilled with random entries from the internal list if needed.
+- If you supply fewer words, the remaining slots are backfilled with random
+  entries from the internal list.
+- The length of the provided password sets the length of all candidate words,
+  overriding the difficulty's normal character-length range.
+
+Example:
+
+```json
+{
+  "hacking": {
+    "difficulty": "Average",
+    "password": "HARDWARE",
+    "dudWords": ["RESEARCH", "SCIENTIST"]
+  }
+}
+```
+
+In this example the password is eight letters long, so every generated word will
+also contain eight characters. Because only two dud words are supplied, the
+terminal backfills the remaining required words with random eight-letter
+candidates.


### PR DESCRIPTION
## Summary
- document how to supply optional hacking passwords and dud words
- clarify that when only `dudWords` are provided, one is chosen as the password and missing slots are backfilled
- note exclusive use of surplus words, backfilling when too few words are given, and overriding word length
- include example JSON snippet showing new behavior

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b8842060e48329affcd0f423fcf7a8