### PR TITLE
Add configurable hacking attempts

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -52,6 +52,8 @@
         <option>Very Hard</option>
       </select>
     </label>
+    <label title="Starting number of attempts available to the user.">Attempts: <input type="number" id="attempts" min="1" value="4"></label>
+    <label title="Maximum number of attempts allowed.">Max Attempts: <input type="number" id="max-attempts" min="1" value="4"></label>
     <label title="Password needed to unlock the terminal after hacking, e.g., HARDWARE.">Password: <input type="text" id="password"></label>
     <label title="Comma-separated words that will be removed as duds during hacking, e.g., RESEARCH, SCIENTIST.">Dud Words: <input type="text" id="dud-words" placeholder="WORD1, WORD2"></label>
     <div id="dud-warning" style="color:red"></div>
@@ -137,6 +139,8 @@ function loadConfig(config) {
   document.getElementById('locked').checked = config.locked || false;
   const diff = config.hacking?.difficulty;
   document.getElementById('difficulty').value = diff === undefined ? 'Random' : diff;
+  attemptsEl.value = config.hacking?.attempts ?? 4;
+  maxAttemptsEl.value = config.hacking?.maxAttempts ?? 4;
   document.getElementById('password').value = config.hacking?.password || '';
   document.getElementById('dud-words').value = (config.hacking?.dudWords || []).join(', ');
 }
@@ -182,6 +186,8 @@ document.getElementById('load-config').addEventListener('click', () => document.
 const passwordEl = document.getElementById('password');
 const dudWordsEl = document.getElementById('dud-words');
 const dudWarningEl = document.getElementById('dud-warning');
+const attemptsEl = document.getElementById('attempts');
+const maxAttemptsEl = document.getElementById('max-attempts');
 
 function validateDudWords() {
   const password = passwordEl.value.trim();
@@ -262,6 +268,8 @@ document.getElementById('builder-form').addEventListener('submit', e => {
     const difficulty = diffValue === 'Random' ? undefined : diffValue;
     const password = passwordEl.value.trim();
     const dudWords = dudWordsEl.value.split(',').map(s => s.trim()).filter(Boolean);
+    const attempts = parseInt(attemptsEl.value, 10);
+    const maxAttempts = parseInt(maxAttemptsEl.value, 10);
     const locked = document.getElementById('locked').checked;
     const textColor = document.getElementById('text-color').value;
     const backgroundColor = document.getElementById('bg-color').value;
@@ -270,6 +278,8 @@ document.getElementById('builder-form').addEventListener('submit', e => {
 
     const hacking = { difficulties: defaultDifficulties };
     if (difficulty) hacking.difficulty = difficulty;
+    if (!isNaN(attempts) && attempts !== 4) hacking.attempts = attempts;
+    if (!isNaN(maxAttempts) && maxAttempts !== 4) hacking.maxAttempts = maxAttempts;
     if (password) hacking.password = password;
     if (dudWords.length) hacking.dudWords = dudWords;
 

--- a/config.json
+++ b/config.json
@@ -128,6 +128,8 @@
   "locked": true,
   "hacking": {
     "difficulty": "Average",
+    "attempts": 4,
+    "maxAttempts": 4,
     "difficulties": [
       { "name": "Very Easy", "wordCount": [8, 10], "length": [4, 5] },
       { "name": "Easy", "wordCount": [10, 12], "length": [6, 7] },

--- a/index.html
+++ b/index.html
@@ -540,9 +540,11 @@ async function startHacking(){
     usedDuds=Array.from(new Set(usedDuds.filter(w=>wordList.includes(w))));
     shuffle(wordList);
     const password=fixedPassword|| (usedDuds.length?usedDuds[Math.floor(Math.random()*usedDuds.length)]:wordList[Math.floor(Math.random()*wordList.length)]);
+    const attempts = hacking.attempts ?? 4;
+    const maxAttempts = hacking.maxAttempts ?? 4;
     hackingData={
-      attempts:4,
-      maxAttempts:4,
+      attempts,
+      maxAttempts,
       password,
       wordList,
       difficulty:diff.name,


### PR DESCRIPTION
## Summary
- Allow configuration of starting and maximum hacking attempts
- Expose attempts and maxAttempts in the config builder
- Read attempt values from configuration when initializing hacking data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b6473c8c8329b13917e6ee449e32