### PR TITLE
Avoid typing audio when animations are skipped

### DIFF
--- a/index.html
+++ b/index.html
@@ -1180,13 +1180,16 @@ async function typeText(el,text){
 }
 
 async function typeUserInput(el,text){
+  const shouldPlay=userSpeed!==Infinity&&userSpeed>0;
   for(let ch of text){
     el.textContent+=ch;
-    playCharFocusSound();
-    if(userSpeed!==Infinity) await sleep(baseDelay*10);
+    if(shouldPlay){
+      playCharFocusSound();
+      await sleep(baseDelay*10);
+    }
   }
   el.textContent+='\n';
-  playEnterCharSound();
+  if(shouldPlay) playEnterCharSound();
 }
 
 function splitEntities(str){


### PR DESCRIPTION
## Summary
- Prevent typing sound effects from playing when animations are skipped by checking user speed.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c7bc349c8329bffc62187d129e91