### PR TITLE
Improve light and dark theme styling

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -8,8 +8,36 @@
   </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
+  <style>
+    body {
+      background-color: #f9fafb;
+      color: #000000;
+    }
+    .dark body {
+      background-color: #000000;
+      color: #f3f4f6;
+    }
+    fieldset {
+      background-color: #f3f4f6;
+      border-color: #d1d5db;
+    }
+    .dark fieldset {
+      background-color: #1f2937;
+      border-color: #374151;
+    }
+    input, textarea, select {
+      background-color: #f9fafb;
+      border-color: #d1d5db;
+      color: #000000;
+    }
+    .dark input, .dark textarea, .dark select {
+      background-color: #111827;
+      border-color: #374151;
+      color: #f3f4f6;
+    }
+  </style>
 </head>
-<body class="font-sans m-0 p-4 bg-white dark:bg-gray-900 dark:text-gray-100">
+<body class="font-sans m-0 p-4">
 <h1 class="text-2xl font-bold mb-4">Config Builder</h1>
 <div class="mb-4 flex gap-2">
   <button type="button" id="load-config" class="px-2 py-1 border rounded" title="Load configuration from a JSON file such as one previously exported.">Load Config</button>


### PR DESCRIPTION
## Summary
- Give config builder a light theme with faint element backgrounds
- Add black-background dark theme and togglable input colors
- Use true black text in light mode

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c6b692f4832998cbeb66538996fc