### PR TITLE
Smooth live drag reordering for terminal builder

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -75,16 +75,16 @@
     </fieldset>
     <fieldset class="p-4 border rounded-lg shadow" title="Define screens and their menu options. Use screen IDs to link options to other screens or leave blank for plain text. Example: a 'help' screen with a RETURN option.">
       <legend class="flex items-center gap-1">Screens</legend>
-      <div>
-        <div v-for="(screen, sIdx) in screens" :key="screen.uid" class="screen mb-4 border border-green-100 rounded bg-green-50 dark:bg-green-900 dark:border-green-700 p-2" draggable="true" @dragstart="drag('screen', sIdx)" @drop="drop('screen', sIdx)" @dragover.prevent>
+      <div @dragover.prevent="over('screen', screens.length)">
+        <div v-for="(screen, sIdx) in screens" :key="screen.uid" class="screen mb-4 border border-green-100 rounded bg-green-50 dark:bg-green-900 dark:border-green-700 p-2" draggable="true" @dragstart="drag('screen', sIdx)" @dragover.prevent="over('screen', sIdx)" @drop="drop()">
           <div class="flex items-center mb-2">
             <button type="button" @click="screen.open = !screen.open" class="mr-2" :aria-expanded="screen.open">{{ screen.open ? '▼' : '►' }}</button>
             <input v-model="screen.id" class="screen-id flex-1 border rounded p-1 mr-2" placeholder="Screen ID">
             <span class="cursor-move text-xl mr-2">↕</span>
             <button type="button" @click="removeScreen(sIdx)" class="text-red-600" title="Remove screen">🗑️</button>
           </div>
-          <div v-show="screen.open" class="pl-6">
-            <div v-for="(item, iIdx) in screen.items" :key="item.uid" class="menu-item mb-1 flex flex-wrap items-center gap-1 bg-green-50 border border-green-100 dark:bg-green-800 dark:border-green-700 p-1 rounded" draggable="true" @dragstart="drag('item', sIdx, iIdx)" @drop="drop('item', sIdx, iIdx)" @dragover.prevent>
+          <div v-show="screen.open" class="pl-6" @dragover.prevent="over('item', sIdx, screen.items.length)">
+            <div v-for="(item, iIdx) in screen.items" :key="item.uid" class="menu-item mb-1 flex flex-wrap items-center gap-1 bg-green-50 border border-green-100 dark:bg-green-800 dark:border-green-700 p-1 rounded" draggable="true" @dragstart="drag('item', sIdx, iIdx)" @dragover.prevent="over('item', sIdx, iIdx)" @drop="drop()">
               <textarea v-model="item.text" rows="2" cols="30" class="menu-text mr-1 border rounded p-1 flex-1" placeholder="Menu text"></textarea>
               <input v-model="item.screen" class="menu-screen mr-1 border rounded p-1 w-24" placeholder="Screen id">
               <input v-model="item.command" class="menu-command mr-1 border rounded p-1 w-32" placeholder="Command">
@@ -114,8 +114,8 @@
       <button type="button" @click="showDifficulties = !showDifficulties" class="mt-2 px-2 py-1 border rounded" title="Edit difficulty levels">Customize Difficulties</button>
       <fieldset id="difficulties-fieldset" class="p-4 border rounded-lg shadow mt-4" title="Define hacking difficulty levels. Each level has a name, word count range, and password length range." v-show="showDifficulties">
         <legend class="flex items-center gap-1">Difficulties</legend>
-        <div>
-          <div v-for="(d, idx) in difficulties" :key="d.uid" class="difficulty-item mb-2 p-2 border rounded bg-gray-50 dark:bg-gray-800" draggable="true" @dragstart="drag('difficulty', idx)" @drop="drop('difficulty', idx)" @dragover.prevent>
+        <div @dragover.prevent="over('difficulty', difficulties.length)">
+          <div v-for="(d, idx) in difficulties" :key="d.uid" class="difficulty-item mb-2 p-2 border rounded bg-gray-50 dark:bg-gray-800" draggable="true" @dragstart="drag('difficulty', idx)" @dragover.prevent="over('difficulty', idx)" @drop="drop()">
             <div class="flex items-center mb-2">
               <button type="button" @click="d.open = !d.open" class="mr-2">{{ d.open ? '▼' : '►' }}</button>
               <input v-model="d.name" class="diff-name mr-2 border rounded p-1" placeholder="Name">
@@ -192,19 +192,28 @@ const app = Vue.createApp({
     drag(type, sIdx, iIdx=null) {
       this.dragging = {type, sIdx, iIdx};
     },
-    drop(type, sIdx, iIdx=null) {
+    over(type, sIdx, iIdx=null) {
       if(!this.dragging || this.dragging.type!==type) return;
       if(type==='screen'){
+        if(sIdx===this.dragging.sIdx) return;
         const [m] = this.screens.splice(this.dragging.sIdx,1);
         this.screens.splice(sIdx,0,m);
+        this.dragging.sIdx = sIdx;
       } else if(type==='item'){
-        const items = this.screens[this.dragging.sIdx].items;
-        const [m] = items.splice(this.dragging.iIdx,1);
-        this.screens[sIdx].items.splice(iIdx,0,m);
+        const from = this.screens[this.dragging.sIdx].items;
+        const [m] = from.splice(this.dragging.iIdx,1);
+        let to = this.screens[sIdx].items;
+        if(sIdx===this.dragging.sIdx && iIdx>this.dragging.iIdx) iIdx--;
+        to.splice(iIdx,0,m);
+        this.dragging = {type, sIdx, iIdx};
       } else if(type==='difficulty'){
+        if(sIdx===this.dragging.sIdx) return;
         const [m] = this.difficulties.splice(this.dragging.sIdx,1);
         this.difficulties.splice(sIdx,0,m);
+        this.dragging.sIdx = sIdx;
       }
+    },
+    drop() {
       this.dragging=null;
     },
     addDifficulty(d={name:'', wordCount:[1,1], length:[1,1]}) {


### PR DESCRIPTION
## Summary
- show live rearrangement of screens, menu items, and difficulties while dragging
- add `over` handler and update drag events to move elements during drag

## Testing
- `npx -y htmlhint builder.html`


------
https://chatgpt.com/codex/tasks/task_e_68b9deee121c8329a15e3b0637e7d3db