### PR TITLE
Add drag placeholders and deferred reordering

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -75,24 +75,32 @@
     </fieldset>
     <fieldset class="p-4 border rounded-lg shadow" title="Define screens and their menu options. Use screen IDs to link options to other screens or leave blank for plain text. Example: a 'help' screen with a RETURN option.">
       <legend class="flex items-center gap-1">Screens</legend>
-      <div @dragover.prevent="over('screen', screens.length)">
-        <div v-for="(screen, sIdx) in screens" :key="screen.uid" class="screen mb-4 border border-green-100 rounded bg-green-50 dark:bg-green-900 dark:border-green-700 p-2" draggable="true" @dragstart="drag('screen', sIdx)" @dragover.prevent="over('screen', sIdx)" @drop="drop()">
-          <div class="flex items-center mb-2">
-            <button type="button" @click="screen.open = !screen.open" class="mr-2" :aria-expanded="screen.open">{{ screen.open ? '▼' : '►' }}</button>
-            <input v-model="screen.id" class="screen-id flex-1 border rounded p-1 mr-2" placeholder="Screen ID">
-            <span class="cursor-move text-xl mr-2">↕</span>
-            <button type="button" @click="removeScreen(sIdx)" class="text-red-600" title="Remove screen">🗑️</button>
-          </div>
-          <div v-show="screen.open" class="pl-6" @dragover.prevent="over('item', sIdx, screen.items.length)">
-            <div v-for="(item, iIdx) in screen.items" :key="item.uid" class="menu-item mb-1 flex flex-wrap items-center gap-1 bg-green-50 border border-green-100 dark:bg-green-800 dark:border-green-700 p-1 rounded" draggable="true" @dragstart="drag('item', sIdx, iIdx)" @dragover.prevent="over('item', sIdx, iIdx)" @drop="drop()">
-              <textarea v-model="item.text" rows="2" cols="30" class="menu-text mr-1 border rounded p-1 flex-1" placeholder="Menu text"></textarea>
-              <input v-model="item.screen" class="menu-screen mr-1 border rounded p-1 w-24" placeholder="Screen id">
-              <input v-model="item.command" class="menu-command mr-1 border rounded p-1 w-32" placeholder="Command">
-              <button type="button" @click="removeMenuItem(sIdx, iIdx)" class="text-red-600" title="Remove item">🗑️</button>
+      <div @dragover.prevent="over('screen', screens.length)" @drop="drop()">
+        <template v-for="(screen, sIdx) in screens">
+          <div v-if="dragging && dragging.type==='screen' && dragging.toSIdx===sIdx" :key="'screen-placeholder-'+sIdx" class="screen mb-4 border-2 border-dashed border-green-400 rounded p-2" @dragover.prevent="over('screen', sIdx)" @drop="drop()"></div>
+          <div :key="screen.uid" class="screen mb-4 border border-green-100 rounded bg-green-50 dark:bg-green-900 dark:border-green-700 p-2" draggable="true" @dragstart="drag('screen', sIdx)" @dragover.prevent="over('screen', sIdx)" @drop="drop()">
+            <div class="flex items-center mb-2">
+              <button type="button" @click="screen.open = !screen.open" class="mr-2" :aria-expanded="screen.open">{{ screen.open ? '▼' : '►' }}</button>
+              <input v-model="screen.id" class="screen-id flex-1 border rounded p-1 mr-2" placeholder="Screen ID">
+              <span class="cursor-move text-xl mr-2">↕</span>
+              <button type="button" @click="removeScreen(sIdx)" class="text-red-600" title="Remove screen">🗑️</button>
             </div>
-            <button type="button" @click="addMenuItem(screen)" class="mt-2 px-2 py-1 border rounded">Add Menu Item</button>
+            <div v-show="screen.open" class="pl-6" @dragover.prevent="over('item', sIdx, screen.items.length)" @drop="drop()">
+              <template v-for="(item, iIdx) in screen.items">
+                <div v-if="dragging && dragging.type==='item' && dragging.toSIdx===sIdx && dragging.toIIdx===iIdx" :key="'item-placeholder-'+sIdx+'-'+iIdx" class="menu-item mb-1 border-2 border-dashed border-green-400 p-1 rounded" @dragover.prevent="over('item', sIdx, iIdx)" @drop="drop()"></div>
+                <div :key="item.uid" class="menu-item mb-1 flex flex-wrap items-center gap-1 bg-green-50 border border-green-100 dark:bg-green-800 dark:border-green-700 p-1 rounded" draggable="true" @dragstart="drag('item', sIdx, iIdx)" @dragover.prevent="over('item', sIdx, iIdx)" @drop="drop()">
+                  <textarea v-model="item.text" rows="2" cols="30" class="menu-text mr-1 border rounded p-1 flex-1" placeholder="Menu text"></textarea>
+                  <input v-model="item.screen" class="menu-screen mr-1 border rounded p-1 w-24" placeholder="Screen id">
+                  <input v-model="item.command" class="menu-command mr-1 border rounded p-1 w-32" placeholder="Command">
+                  <button type="button" @click="removeMenuItem(sIdx, iIdx)" class="text-red-600" title="Remove item">🗑️</button>
+                </div>
+              </template>
+              <div v-if="dragging && dragging.type==='item' && dragging.toSIdx===sIdx && dragging.toIIdx===screen.items.length" :key="'item-placeholder-'+sIdx+'-end'" class="menu-item mb-1 border-2 border-dashed border-green-400 p-1 rounded" @dragover.prevent="over('item', sIdx, screen.items.length)" @drop="drop()"></div>
+              <button type="button" @click="addMenuItem(screen)" class="mt-2 px-2 py-1 border rounded">Add Menu Item</button>
+            </div>
           </div>
-        </div>
+        </template>
+        <div v-if="dragging && dragging.type==='screen' && dragging.toSIdx===screens.length" :key="'screen-placeholder-end'" class="screen mb-4 border-2 border-dashed border-green-400 rounded p-2" @dragover.prevent="over('screen', screens.length)" @drop="drop()"></div>
         <button type="button" @click="addScreen()" class="mt-2 px-2 py-1 border rounded">Add Screen</button>
       </div>
     </fieldset>
@@ -190,30 +198,35 @@ const app = Vue.createApp({
       this.screens[sIdx].items.splice(iIdx,1);
     },
     drag(type, sIdx, iIdx=null) {
-      this.dragging = {type, sIdx, iIdx};
+      this.dragging = {type, fromSIdx:sIdx, fromIIdx:iIdx, toSIdx:sIdx, toIIdx:iIdx};
     },
     over(type, sIdx, iIdx=null) {
       if(!this.dragging || this.dragging.type!==type) return;
       if(type==='screen'){
-        if(sIdx===this.dragging.sIdx) return;
-        const [m] = this.screens.splice(this.dragging.sIdx,1);
-        this.screens.splice(sIdx,0,m);
-        this.dragging.sIdx = sIdx;
+        this.dragging.toSIdx = sIdx;
       } else if(type==='item'){
-        const from = this.screens[this.dragging.sIdx].items;
-        const [m] = from.splice(this.dragging.iIdx,1);
-        let to = this.screens[sIdx].items;
-        if(sIdx===this.dragging.sIdx && iIdx>this.dragging.iIdx) iIdx--;
-        to.splice(iIdx,0,m);
-        this.dragging = {type, sIdx, iIdx};
+        this.dragging.toSIdx = sIdx;
+        this.dragging.toIIdx = iIdx;
       } else if(type==='difficulty'){
-        if(sIdx===this.dragging.sIdx) return;
-        const [m] = this.difficulties.splice(this.dragging.sIdx,1);
-        this.difficulties.splice(sIdx,0,m);
-        this.dragging.sIdx = sIdx;
+        this.dragging.toSIdx = sIdx;
       }
     },
     drop() {
+      const d = this.dragging;
+      if(!d) return;
+      if(d.type==='screen'){
+        const [m] = this.screens.splice(d.fromSIdx,1);
+        this.screens.splice(d.toSIdx,0,m);
+      } else if(d.type==='item'){
+        const from = this.screens[d.fromSIdx].items;
+        const [m] = from.splice(d.fromIIdx,1);
+        let to = this.screens[d.toSIdx].items;
+        if(d.fromSIdx===d.toSIdx && d.toIIdx>d.fromIIdx) d.toIIdx--;
+        to.splice(d.toIIdx,0,m);
+      } else if(d.type==='difficulty'){
+        const [m] = this.difficulties.splice(d.fromSIdx,1);
+        this.difficulties.splice(d.toSIdx,0,m);
+      }
       this.dragging=null;
     },
     addDifficulty(d={name:'', wordCount:[1,1], length:[1,1]}) {


### PR DESCRIPTION
## Summary
- Defer array splicing until drop and track target indices during drag
- Add placeholder elements for screens and menu items to indicate drop targets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e89336a08329a5ce99247c290a8d