### PR TITLE
style: enhance builder buttons and tabs

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -63,19 +63,19 @@
 <body class="font-sans m-0 p-4">
 <h1 class="text-2xl font-bold mb-4">Config Builder</h1>
 <div class="mb-4 flex gap-2 items-center">
-  <button type="button" id="load-config" class="px-2 py-1 border rounded" title="Load configuration from a JSON file such as one previously exported.">Load Config</button>
-  <button type="submit" form="builder-form" class="px-2 py-1 border rounded" title="Generate the configuration file, update the preview, and enable downloading config.json">Generate Config</button>
+  <button type="button" id="load-config" class="px-2 py-1 border-2 border-gray-600 rounded bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:border-gray-400 dark:hover:bg-gray-700" title="Load configuration from a JSON file such as one previously exported.">Load Config</button>
+  <button type="submit" form="builder-form" class="px-2 py-1 border-2 border-gray-600 rounded bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:border-gray-400 dark:hover:bg-gray-700" title="Generate the configuration file, update the preview, and enable downloading config.json">Generate Config</button>
   <a id="download-link" class="hidden text-blue-600 underline" download="config.json">Download config.json</a>
-  <button type="button" id="dark-toggle" class="px-2 py-1 border rounded" title="Toggle dark mode">Toggle Dark Mode</button>
+  <button type="button" id="dark-toggle" class="px-2 py-1 border-2 border-gray-600 rounded bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:border-gray-400 dark:hover:bg-gray-700" title="Toggle dark mode">Toggle Dark Mode</button>
 </div>
 <input type="file" id="config-file" accept="application/json" class="hidden">
 <div id="builder-layout" class="flex flex-col lg:flex-row items-start gap-4">
 <form id="builder-form" class="flex-1">
-  <div class="mb-4 border-b flex gap-4">
-    <button type="button" @click="activeTab='content'" :class="['px-2 py-1', activeTab==='content' ? 'border-b-2' : 'text-gray-500']">Terminal Content</button>
-    <button type="button" @click="activeTab='hacking'" :class="['px-2 py-1', activeTab==='hacking' ? 'border-b-2' : 'text-gray-500']">Hacking</button>
-    <button type="button" @click="activeTab='prefs'" :class="['px-2 py-1', activeTab==='prefs' ? 'border-b-2' : 'text-gray-500']">Preferences</button>
-  </div>
+    <div class="mb-4 flex gap-2 border-b-2 border-gray-300 dark:border-gray-700">
+      <button type="button" @click="activeTab='content'" :class="['px-2 py-1 border-2 rounded-t', activeTab==='content' ? 'bg-gray-100 border-gray-600 dark:bg-gray-800 dark:border-gray-400' : 'bg-gray-50 border-gray-300 text-gray-500 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-400']">Terminal Content</button>
+      <button type="button" @click="activeTab='hacking'" :class="['px-2 py-1 border-2 rounded-t', activeTab==='hacking' ? 'bg-gray-100 border-gray-600 dark:bg-gray-800 dark:border-gray-400' : 'bg-gray-50 border-gray-300 text-gray-500 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-400']">Hacking</button>
+      <button type="button" @click="activeTab='prefs'" :class="['px-2 py-1 border-2 rounded-t', activeTab==='prefs' ? 'bg-gray-100 border-gray-600 dark:bg-gray-800 dark:border-gray-400' : 'bg-gray-50 border-gray-300 text-gray-500 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-400']">Preferences</button>
+    </div>
   <div v-show="activeTab==='content'" class="space-y-4">
     <fieldset class="p-4 border rounded-lg shadow" title="Enter the lines displayed at the top of the terminal. Each line becomes a separate title line. Example: 'ROBCO INDUSTRIES UNIFIED OPERATING SYSTEM'.">
       <legend class="flex items-center gap-1">Titles</legend>


### PR DESCRIPTION
## Summary
- highlight builder action buttons with thicker borders and hover backgrounds
- add clearer tab styling with borders and distinct active/inactive states

## Testing
- `npm test` *(fails: package.json not found)*
- `python -m pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba249d9e208329b193aa920a98f8d0