### PR TITLE
feat: add per-screen appearance options

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -98,10 +98,16 @@
               <button type="button" @click="screen.open = !screen.open" class="mr-2" :aria-expanded="screen.open">{{ screen.open ? '▼' : '►' }}</button>
               <input v-model="screen.id" class="screen-id flex-1 border rounded p-1 mr-2" placeholder="Screen ID">
               <input type="color" v-model="screen.color" class="screen-color w-8 h-8 p-0 border-2 rounded mr-2 shadow cursor-pointer" title="Color is for organization only and does not affect terminal appearance">
+              <button type="button" @click="screen.showAppearance = !screen.showAppearance" class="mr-2" title="Toggle appearance options">Appearance</button>
               <button type="button" @click="moveScreenUp(sIdx)" :disabled="sIdx===0" class="mr-1" title="Move up">▲</button>
               <button type="button" @click="moveScreenDown(sIdx)" :disabled="sIdx===screens.length-1" class="mr-1" title="Move down">▼</button>
               <span class="cursor-move text-xl mr-2">↕</span>
               <button type="button" @click="removeScreen(sIdx)" class="text-red-600" title="Remove screen">🗑️</button>
+            </div>
+            <div v-show="screen.showAppearance" class="pl-6 mb-2 space-y-1">
+              <label class="block">Text: <input type="color" v-model="screen.textColor" class="ml-2"></label>
+              <label class="block">Background: <input type="color" v-model="screen.bgColor" class="ml-2"></label>
+              <label class="block">Border: <input type="color" v-model="screen.borderColor" class="ml-2"></label>
             </div>
             <div v-show="screen.open" class="pl-6 items-container" :data-sidx="sIdx" :id="'items-'+screen.uid">
               <template v-for="(item, iIdx) in screen.items">
@@ -213,7 +219,11 @@ const app = Vue.createApp({
           color,
           items:[{text:'', screen:'', command:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()}],
           open:true,
-          uid:crypto.randomUUID?crypto.randomUUID():Math.random()
+          uid:crypto.randomUUID?crypto.randomUUID():Math.random(),
+          textColor:'',
+          bgColor:'',
+          borderColor:'',
+          showAppearance:false
         });
         this.$nextTick(this.initSortables);
       },
@@ -335,8 +345,14 @@ const app = Vue.createApp({
       document.getElementById('headers').value = (config.headerLines || []).join('\n');
       document.getElementById('boot-lines').value = (config.bootLines || []).join('\n');
       this.screens = [];
-      Object.entries(config.screens || {}).forEach(([id, items]) => {
-        const screen = {id, color:'#cccccc', items:[], open:true, uid:crypto.randomUUID?crypto.randomUUID():Math.random()};
+      Object.entries(config.screens || {}).forEach(([id, data]) => {
+        const screen = {id, color:'#cccccc', items:[], open:true, uid:crypto.randomUUID?crypto.randomUUID():Math.random(), textColor:'', bgColor:'', borderColor:'', showAppearance:false};
+        const items = Array.isArray(data) ? data : (data.items || []);
+        if(!Array.isArray(data) && data.style){
+          screen.textColor = data.style.textColor || '';
+          screen.bgColor = data.style.backgroundColor || '';
+          screen.borderColor = data.style.borderColor || '';
+        }
         items.forEach(item=>{
           if (typeof item === 'string') {
             screen.items.push({text:item, screen:'', command:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
@@ -403,7 +419,11 @@ const app = Vue.createApp({
           else if(command){ items.push({text,command}); }
           else { items.push(text); }
         });
-        screensObj[id]=items;
+        const style = {};
+        if(scr.textColor) style.textColor = scr.textColor;
+        if(scr.bgColor) style.backgroundColor = scr.bgColor;
+        if(scr.borderColor) style.borderColor = scr.borderColor;
+        screensObj[id] = Object.keys(style).length ? {items, style} : items;
       });
       const diffValue = this.difficultyChoice;
       const difficulty = diffValue === 'Random' ? undefined : diffValue;

--- a/index.html
+++ b/index.html
@@ -342,6 +342,7 @@ let bootLines=defaultBootLines;
 let screens={};
 let hacking={};
 let startLocked=true;
+let baseStyle={textColor:'#7aff7a',backgroundColor:'#041204',borderColor:'#008800'};
 
 let uploadedConfig=null;
 window.addEventListener('message', e => { uploadedConfig = e.data; loadConfig(); });
@@ -360,7 +361,7 @@ async function loadConfig(){
   titleLines=cfg.titleLines;
   headerLines=cfg.headerLines;
   bootLines = Array.isArray(cfg.bootLines) && cfg.bootLines.length ? cfg.bootLines : defaultBootLines;
-  screens=cfg.screens;
+  screens=cfg.screens || {};
   hacking = cfg.hacking || {};
   if(savedUserSpeed===null && cfg.userSpeed!==undefined){
     userBaseSpeed=cfg.userSpeed===0?Infinity:cfg.userSpeed;
@@ -372,12 +373,18 @@ async function loadConfig(){
     compSpeed=compBaseSpeed;
     if(compSpeedSlider) compSpeedSlider.value=compBaseSpeed===Infinity?0:compBaseSpeed;
   }
-    if(cfg.style){
-      const {textColor, backgroundColor, borderColor}=cfg.style;
-      if(textColor) document.documentElement.style.setProperty('--text-color', textColor);
-      if(backgroundColor) document.documentElement.style.setProperty('--terminal-bg', backgroundColor);
-      if(borderColor) document.documentElement.style.setProperty('--border-color', borderColor);
-    }
+  if(cfg.style){
+    const {textColor, backgroundColor, borderColor}=cfg.style;
+    if(textColor) document.documentElement.style.setProperty('--text-color', textColor);
+    if(backgroundColor) document.documentElement.style.setProperty('--terminal-bg', backgroundColor);
+    if(borderColor) document.documentElement.style.setProperty('--border-color', borderColor);
+  }
+  const computed=getComputedStyle(document.documentElement);
+  baseStyle={
+    textColor:computed.getPropertyValue('--text-color').trim(),
+    backgroundColor:computed.getPropertyValue('--terminal-bg').trim(),
+    borderColor:computed.getPropertyValue('--border-color').trim()
+  };
   startLocked=cfg.locked!==undefined?cfg.locked:true;
   if(hasHacked) startLocked=false;
 }
@@ -438,6 +445,15 @@ function restoreInput(){
   if(input.parentElement!==terminalScreen){
     terminalScreen.appendChild(input);
   }
+}
+
+function applyScreenStyle(style){
+  const t=style&&style.textColor?style.textColor:baseStyle.textColor;
+  const b=style&&style.backgroundColor?style.backgroundColor:baseStyle.backgroundColor;
+  const br=style&&style.borderColor?style.borderColor:baseStyle.borderColor;
+  document.documentElement.style.setProperty('--text-color',t);
+  document.documentElement.style.setProperty('--terminal-bg',b);
+  document.documentElement.style.setProperty('--border-color',br);
 }
 
 const prefContainer=document.getElementById('pref-container');
@@ -1426,7 +1442,16 @@ async function showScreen(name){
   content.innerHTML='';
   currentOptions=[];
   selected=-1;
-  const lines=screens[name];
+  const data=screens[name];
+  let lines=[];
+  let style=null;
+  if(Array.isArray(data)){
+    lines=data;
+  }else if(data){
+    lines=data.items||[];
+    style=data.style||null;
+  }
+  applyScreenStyle(style);
   let i=0;
   while(i<lines.length){
     resetSpeeds();


### PR DESCRIPTION
## Summary
- Allow each screen to override terminal text, background, and border colors
- Builder UI now exposes per-screen appearance controls hidden behind an appearance toggle
- Config generator and runtime apply screen-specific styles while falling back to global defaults

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba24ba0d808329ab668911e00ace3f