### PR TITLE
Use theme text color for control buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@
   }
   #power-button, #config-button, #pref-button{
     background:#b3410e;
-    color:#fff;
+    color:var(--text-color);
     border:calc(2px * var(--scale)) solid var(--border-color);
     width:max(44px, calc(40px * var(--scale)));
     height:max(44px, calc(40px * var(--scale)));


### PR DESCRIPTION
## Summary
- reference shared `--text-color` variable for control button text to support light and dark themes

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba344df09883298b7c546bf5c1978c