### PR TITLE
Replace text speed sliders with preset options

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -233,11 +233,6 @@
         <input type="text" id="bg-color-hex" class="ml-2 border rounded p-1 w-24" v-model="bgColor">
       </label>
     </fieldset>
-    <fieldset class="p-4 border rounded-lg shadow" title="Default typing speeds. 0 is slowest, 100 is instant.">
-      <legend class="flex items-center gap-1">Text Speeds</legend>
-      <label class="block">User Text Speed: <input type="number" id="user-speed" min="0" max="100" value="50" class="ml-2 border rounded p-1 w-20"></label>
-      <label class="block">Terminal Text Speed: <input type="number" id="comp-speed" min="0" max="100" value="50" class="ml-2 border rounded p-1 w-20"></label>
-    </fieldset>
   </div>
 </form>
 <script>
@@ -379,8 +374,6 @@ const app = Vue.createApp({
           if(!screen.items.length) screen.items.push({text:'', screen:'', command:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
           this.screens.push(screen);
         });
-        document.getElementById('user-speed').value = config.userSpeed ?? 50;
-        document.getElementById('comp-speed').value = config.compSpeed ?? 50;
         document.getElementById('locked').checked = config.locked || false;
         const diffs = config.hacking?.difficulties || defaultDifficulties;
         this.difficulties = [];
@@ -441,8 +434,6 @@ const app = Vue.createApp({
       if(hackTextColor !== textColor) hackingStyle.textColor = hackTextColor;
       if(hackBgColor !== backgroundColor) hackingStyle.backgroundColor = hackBgColor;
       if(hackBorderColor !== borderColor) hackingStyle.borderColor = hackBorderColor;
-      const userSpeed = parseInt(document.getElementById('user-speed').value, 10);
-      const compSpeed = parseInt(document.getElementById('comp-speed').value, 10);
       const hacking = { difficulties: this.difficulties.map(({name, wordCount, length})=>({name, wordCount, length})) };
       if (difficulty) hacking.difficulty = difficulty;
       if (!isNaN(attempts) && attempts !== 4) hacking.attempts = attempts;
@@ -453,8 +444,6 @@ const app = Vue.createApp({
         titleLines: titles,
         headerLines: headers,
         bootLines,
-        userSpeed: isNaN(userSpeed) ? 50 : userSpeed,
-        compSpeed: isNaN(compSpeed) ? 50 : compSpeed,
         screens: screensObj,
         style,
         hackingStyle: Object.keys(hackingStyle).length ? hackingStyle : undefined,

--- a/index.html
+++ b/index.html
@@ -121,6 +121,12 @@
   #pref-menu label:last-child{
     margin-bottom:0;
   }
+  #pref-menu select{
+    margin-left:calc(5px * var(--scale));
+    background:var(--terminal-bg);
+    color:var(--text-color);
+    border:calc(1px * var(--scale)) solid var(--border-color);
+  }
   #pref-menu input[type=range]{
     margin-left:calc(5px * var(--scale));
     -webkit-appearance:none;
@@ -309,8 +315,22 @@
         <label>Scroll <input type="range" min="0" max="100" value="20" id="scroll-volume"></label>
         <label>Focus <input type="range" min="0" max="100" value="20" id="focus-volume"></label>
         <label>Select <input type="range" min="0" max="100" value="50" id="select-volume"></label>
-        <label>User Text Speed <input type="range" min="0" max="100" value="50" id="user-speed-slider"></label>
-        <label>Terminal Text Speed <input type="range" min="0" max="100" value="50" id="comp-speed-slider"></label>
+        <label>User Text Speed
+          <select id="user-speed-select">
+            <option value="100">Skip</option>
+            <option value="35">Slow</option>
+            <option value="50" selected>Normal</option>
+            <option value="65">Fast</option>
+          </select>
+        </label>
+        <label>Terminal Text Speed
+          <select id="comp-speed-select">
+            <option value="100">Skip</option>
+            <option value="35">Slow</option>
+            <option value="50" selected>Normal</option>
+            <option value="65">Fast</option>
+          </select>
+        </label>
       </div>
     </div>
     <div id="config-container">
@@ -422,12 +442,12 @@ async function loadConfig(cycle=currentCycle){
   if(savedUserSpeed===null && cfg.userSpeed!==undefined){
     userBaseSpeed=cfg.userSpeed;
     userSpeed=userBaseSpeed;
-    if(userSpeedSlider) userSpeedSlider.value=userBaseSpeed;
+    if(userSpeedSelect) userSpeedSelect.value=String([35,50,65,100].includes(userBaseSpeed)?userBaseSpeed:50);
   }
   if(savedCompSpeed===null && cfg.compSpeed!==undefined){
     compBaseSpeed=cfg.compSpeed;
     compSpeed=compBaseSpeed;
-    if(compSpeedSlider) compSpeedSlider.value=compBaseSpeed;
+    if(compSpeedSelect) compSpeedSelect.value=String([35,50,65,100].includes(compBaseSpeed)?compBaseSpeed:50);
   }
   if(cfg.style){
     const {textColor, backgroundColor, borderColor}=cfg.style;
@@ -537,8 +557,8 @@ const humSlider=document.getElementById('hum-volume');
 const scrollSlider=document.getElementById('scroll-volume');
 const focusSlider=document.getElementById('focus-volume');
 const selectSlider=document.getElementById('select-volume');
-const userSpeedSlider=document.getElementById('user-speed-slider');
-const compSpeedSlider=document.getElementById('comp-speed-slider');
+const userSpeedSelect=document.getElementById('user-speed-select');
+const compSpeedSelect=document.getElementById('comp-speed-select');
 
 prefButton.addEventListener('click',()=>{
   prefMenu.style.display=prefMenu.style.display==='flex'?'none':'flex';
@@ -557,17 +577,17 @@ humSlider.addEventListener('input',()=>{
 scrollSlider.addEventListener('input',()=>{scrollVolume=scrollSlider.value/100;});
 focusSlider.addEventListener('input',()=>{focusVolume=focusSlider.value/100;});
 selectSlider.addEventListener('input',()=>{selectVolume=selectSlider.value/100;});
-userSpeedSlider.value=userSpeed;
-compSpeedSlider.value=compSpeed;
-userSpeedSlider.addEventListener('input',()=>{
-  const val=Number(userSpeedSlider.value);
+userSpeedSelect.value=String([35,50,65,100].includes(userBaseSpeed)?userBaseSpeed:50);
+compSpeedSelect.value=String([35,50,65,100].includes(compBaseSpeed)?compBaseSpeed:50);
+userSpeedSelect.addEventListener('change',()=>{
+  const val=Number(userSpeedSelect.value);
   userBaseSpeed=val;
   userSpeed=userBaseSpeed;
   localStorage.setItem('userSpeed',userBaseSpeed);
   savedUserSpeed=userBaseSpeed;
 });
-compSpeedSlider.addEventListener('input',()=>{
-  const val=Number(compSpeedSlider.value);
+compSpeedSelect.addEventListener('change',()=>{
+  const val=Number(compSpeedSelect.value);
   compBaseSpeed=val;
   compSpeed=compBaseSpeed;
   localStorage.setItem('compSpeed',compBaseSpeed);


### PR DESCRIPTION
## Summary
- Remove text speed controls from the config builder.
- Add Skip, Slow, Normal, and Fast presets for user and terminal text speeds in preferences menu.
- Persist selected speed presets via new dropdowns instead of sliders.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6a251e408329a9aad749abc45af3