### PR TITLE
Increase default user typing speed

### DIFF
--- a/config.json
+++ b/config.json
@@ -19,7 +19,7 @@
     "Root (5A8)",
     "Maintenance Mode"
   ],
-  "userSpeed": 68,
+  "userSpeed": 75,
   "compSpeed": 90,
   "screens": {
     "menu": [

--- a/index.html
+++ b/index.html
@@ -318,9 +318,9 @@
         <label>User Text Speed
           <select id="user-speed-select">
             <option value="100">Skip</option>
-            <option value="53">Slow</option>
-            <option value="68" selected>Normal</option>
-            <option value="83">Fast</option>
+            <option value="58">Slow</option>
+            <option value="75" selected>Normal</option>
+            <option value="91">Fast</option>
           </select>
         </label>
         <label>Terminal Text Speed
@@ -442,7 +442,7 @@ async function loadConfig(cycle=currentCycle){
   if(savedUserSpeed===null && cfg.userSpeed!==undefined){
     userBaseSpeed=cfg.userSpeed;
     userSpeed=userBaseSpeed;
-    if(userSpeedSelect) userSpeedSelect.value=String([53,68,83,100].includes(userBaseSpeed)?userBaseSpeed:68);
+    if(userSpeedSelect) userSpeedSelect.value=String([58,75,91,100].includes(userBaseSpeed)?userBaseSpeed:75);
   }
   if(savedCompSpeed===null && cfg.compSpeed!==undefined){
     compBaseSpeed=cfg.compSpeed;
@@ -516,7 +516,7 @@ let typing=false;
 let baseDelay=10;
 let savedUserSpeed=localStorage.getItem('userSpeed');
 let savedCompSpeed=localStorage.getItem('compSpeed');
-let userBaseSpeed=savedUserSpeed!==null?Number(savedUserSpeed):68;
+let userBaseSpeed=savedUserSpeed!==null?Number(savedUserSpeed):75;
 let compBaseSpeed=savedCompSpeed!==null?Number(savedCompSpeed):90;
 let userSpeed=userBaseSpeed;
 let compSpeed=compBaseSpeed;
@@ -577,7 +577,7 @@ humSlider.addEventListener('input',()=>{
 scrollSlider.addEventListener('input',()=>{scrollVolume=scrollSlider.value/100;});
 focusSlider.addEventListener('input',()=>{focusVolume=focusSlider.value/100;});
 selectSlider.addEventListener('input',()=>{selectVolume=selectSlider.value/100;});
-userSpeedSelect.value=String([53,68,83,100].includes(userBaseSpeed)?userBaseSpeed:68);
+userSpeedSelect.value=String([58,75,91,100].includes(userBaseSpeed)?userBaseSpeed:75);
 compSpeedSelect.value=String([80,90,95,100].includes(compBaseSpeed)?compBaseSpeed:90);
 userSpeedSelect.addEventListener('change',()=>{
   const val=Number(userSpeedSelect.value);


### PR DESCRIPTION
## Summary
- Raise default user typing speed by 10%
- Align user speed options and initialization logic with new base speed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba72c2a9f883298862970f1bed7913