### PR TITLE
Adjust default fan hum volume

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,7 +311,7 @@
       <button id="pref-button" aria-label="Preferences">&#9881;</button>
       <span>Prefs</span>
       <div id="pref-menu">
-        <label>Hum <input type="range" min="0" max="100" value="30" id="hum-volume"></label>
+        <label>Hum <input type="range" min="0" max="100" value="20" id="hum-volume"></label>
         <label>Scroll <input type="range" min="0" max="100" value="20" id="scroll-volume"></label>
         <label>Focus <input type="range" min="0" max="100" value="20" id="focus-volume"></label>
         <label>Select <input type="range" min="0" max="100" value="50" id="select-volume"></label>
@@ -1180,6 +1180,7 @@ async function startFanHum(){
   fanHumSource=audioCtx.createBufferSource();
   fanHumSource.buffer=fanHumBuffer;
   fanHumSource.loop=true;
+  fanHumGain.gain.value=humVolume;
   fanHumSource.connect(fanHumGain);
   fanHumSource.start(0);
 }


### PR DESCRIPTION
## Summary
- Set fan hum volume slider default to 20% for lower startup volume
- Ensure fan hum audio gain applies current volume when sound starts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba73e9bb208329bc310580cd097f0b