### PR TITLE
Ensure menu commands run after screen change

### DIFF
--- a/index.html
+++ b/index.html
@@ -1581,7 +1581,10 @@ async function showScreen(name){
           playSelectSound();
           if(line.screen){
             await showScreen(line.screen);
-            if(line.command) displayMessage(line.command);
+            if(line.command){
+              await new Promise(requestAnimationFrame);
+              displayMessage(line.command);
+            }
           }else if(line.command){
             displayMessage(line.command);
           }


### PR DESCRIPTION
## Summary
- Wait for a screen render cycle before executing command messages when a menu option switches screens.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7b0b39a08329ac29e78db4f15048