### PR TITLE
Move screen color controls below header

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -161,26 +161,30 @@
       <div id="screens-container">
         <template v-for="(screen, sIdx) in screens">
           <div :key="screen.uid" class="screen mb-4 border border-l-4 rounded p-2 text-white" :style="{borderColor: screen.color, backgroundColor: screen.color}">
-            <div class="flex flex-wrap items-center mb-2">
-              <button type="button" @click="screen.open = !screen.open" class="mr-2 action-btn" :aria-expanded="screen.open">{{ screen.open ? '▼' : '►' }}</button>
-              <label class="flex items-center mr-2">Text:
-                <input type="color" v-model="screen.textColor" class="ml-1">
-                <input type="text" v-model="screen.textColor" class="ml-1 border rounded p-1 w-24">
-              </label>
-              <label class="flex items-center mr-2">Background:
-                <input type="color" v-model="screen.bgColor" class="ml-1">
-                <input type="text" v-model="screen.bgColor" class="ml-1 border rounded p-1 w-24">
-              </label>
-              <label class="flex items-center mr-2">Border:
-                <input type="color" v-model="screen.borderColor" class="ml-1">
-                <input type="text" v-model="screen.borderColor" class="ml-1 border rounded p-1 w-24">
-              </label>
-              <input v-model="screen.id" class="screen-id flex-1 border rounded p-1 mr-2" placeholder="Screen ID">
-              <input type="color" v-model="screen.color" class="screen-color w-8 h-8 p-0 border-2 rounded mr-2 shadow cursor-pointer" title="Color is for organization only and does not affect terminal appearance">
-              <input type="text" v-model="screen.color" class="w-20 p-1 border rounded mr-2" title="Color is for organization only and does not affect terminal appearance">
-              <button type="button" @click="moveScreenUp(sIdx)" :disabled="sIdx===0" class="mr-1 action-btn" title="Move up">▲</button>
-              <button type="button" @click="moveScreenDown(sIdx)" :disabled="sIdx===screens.length-1" class="mr-1 action-btn" title="Move down">▼</button>
-              <button type="button" @click="removeScreen(sIdx)" class="action-btn" title="Remove screen"><span class="w-4 h-4 flex items-center justify-center text-black dark:text-white">&times;</span></button>
+            <div class="mb-2">
+              <div class="flex flex-wrap items-center mb-2">
+                <button type="button" @click="screen.open = !screen.open" class="mr-2 action-btn" :aria-expanded="screen.open">{{screen.open ? '▼' : '►' }}</button>
+                <input v-model="screen.id" class="screen-id flex-1 border rounded p-1 mr-2" placeholder="Screen ID">
+                <input type="color" v-model="screen.color" class="screen-color w-8 h-8 p-0 border-2 rounded mr-2 shadow cursor-pointer" title="Color is for organization only and does not affect terminal appearance">
+                <input type="text" v-model="screen.color" class="w-20 p-1 border rounded mr-2" title="Color is for organization only and does not affect terminal appearance">
+                <button type="button" @click="moveScreenUp(sIdx)" :disabled="sIdx===0" class="mr-1 action-btn" title="Move up">▲</button>
+                <button type="button" @click="moveScreenDown(sIdx)" :disabled="sIdx===screens.length-1" class="mr-1 action-btn" title="Move down">▼</button>
+                <button type="button" @click="removeScreen(sIdx)" class="action-btn" title="Remove screen"><span class="w-4 h-4 flex items-center justify-center text-black dark:text-white">&times;</span></button>
+              </div>
+              <div class="flex flex-wrap items-center">
+                <label class="flex items-center mr-2">Text:
+                  <input type="color" v-model="screen.textColor" class="ml-1">
+                  <input type="text" v-model="screen.textColor" class="ml-1 border rounded p-1 w-24">
+                </label>
+                <label class="flex items-center mr-2">Background:
+                  <input type="color" v-model="screen.bgColor" class="ml-1">
+                  <input type="text" v-model="screen.bgColor" class="ml-1 border rounded p-1 w-24">
+                </label>
+                <label class="flex items-center mr-2">Border:
+                  <input type="color" v-model="screen.borderColor" class="ml-1">
+                  <input type="text" v-model="screen.borderColor" class="ml-1 border rounded p-1 w-24">
+                </label>
+              </div>
             </div>
             <div v-show="screen.open" class="pl-6 items-container" :data-sidx="sIdx" :id="'items-'+screen.uid">
               <template v-for="(item, iIdx) in screen.items">


### PR DESCRIPTION
## Summary
- Reorganize screen editor layout so text, background, and border color inputs appear on a second line beneath the screen header

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb529f20e08329a9deea7b8f7949cb