### PR TITLE
Improve spacing and center terminal header

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,9 @@
     box-sizing:border-box;
     padding:calc(env(safe-area-inset-top) + 8px) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
   }
+  br{
+    line-height:0.7;
+  }
   #terminal-wrapper{
     position:relative;
     width:calc(828px * var(--scale));
@@ -290,7 +293,7 @@
   #content.hack-content{display:flex;flex-direction:column;justify-content:flex-start;padding:calc(4px * var(--scale));padding-bottom:calc(22px * var(--scale));}
   #header.hack-header{padding-top:calc(16px * var(--scale));padding-bottom:calc(4px * var(--scale));}
   #header.hack-header #hack-title{margin-top:calc(4px * var(--scale));margin-bottom:calc(8px * var(--scale));}
-  #header.hack-header #attempts{margin-bottom:calc(4px * var(--scale));}
+  #header.hack-header #attempts{margin:calc(4px * var(--scale)) 0;}
     #header.hack-header #hack-warning{margin-bottom:calc(4px * var(--scale));}
     #terminal-screen{height:100%;display:flex;flex-direction:column;transition:transform 1s linear;}
     #terminal.locking #terminal-screen{transform:translateY(-100%);}
@@ -1532,16 +1535,19 @@ async function showIntro(){
   content.innerHTML='';
   header.classList.remove('hack-header');
   content.classList.remove('hack-content');
-  header.style.marginLeft='-2ch';
-  header.style.textAlign='left';
+  const termStyle=getComputedStyle(terminal);
+  const padLeft=parseFloat(termStyle.paddingLeft);
+  const padRight=parseFloat(termStyle.paddingRight);
+  header.style.marginLeft=`${(padLeft-padRight)/-2}px`;
+  header.style.textAlign='center';
   for(const line of titleLines){
     const div=document.createElement('div');
-    div.style.textAlign='center';
     header.appendChild(div);
     await typeText(div,line);
   }
   for(const line of headerLines){
     const div=document.createElement('div');
+    div.style.textAlign='left';
     div.style.marginLeft='2ch';
     header.appendChild(div);
     await typeText(div,line);


### PR DESCRIPTION
## Summary
- Reduce empty line spacing by 30%
- Add vertical padding around hacking attempt counter
- Dynamically center the terminal header

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9652d4cc8329a8638a979e3d98a7