### PR TITLE
Refine hacking screen spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,7 +283,7 @@
   #hacking .bracket.highlight{background:var(--hacking-border-color);color:var(--hacking-bg);}
   #hack-messages{white-space:pre;display:flex;flex-direction:column;justify-content:flex-end;align-items:flex-start;height:100%;flex:1;line-height:1;align-self:flex-start;padding:0 calc(8px * var(--scale)) calc(24px * var(--scale)) 0;overflow:hidden;}
   #hack-messages #input{margin-top:0;align-self:flex-start;}
-  #hack-prompt{margin-top:calc(4px * var(--scale));}
+  #hack-prompt{margin-top:0;margin-bottom:calc(20px * var(--scale));}
   .hack-message{text-align:left;}
   .hack-row{line-height:1;}
   .hack-addr{display:inline-block;width:6ch;}
@@ -292,8 +292,8 @@
   #hacking, .hack-row { letter-spacing: inherit; }
   #content.hack-content{display:flex;flex-direction:column;justify-content:flex-start;padding:calc(4px * var(--scale));padding-bottom:calc(22px * var(--scale));}
   #header.hack-header{padding-top:calc(16px * var(--scale));padding-bottom:calc(4px * var(--scale));}
-  #header.hack-header #hack-title{margin-top:calc(4px * var(--scale));margin-bottom:calc(8px * var(--scale));}
-  #header.hack-header #attempts{margin:calc(4px * var(--scale)) 0;}
+  #header.hack-header #hack-title{margin-top:0;margin-bottom:calc(2px * var(--scale));}
+  #header.hack-header #attempts{margin:0;}
     #header.hack-header #hack-warning{margin-bottom:calc(4px * var(--scale));}
     #terminal-screen{height:100%;display:flex;flex-direction:column;transition:transform 1s linear;}
     #terminal.locking #terminal-screen{transform:translateY(-100%);}


### PR DESCRIPTION
## Summary
- Reduce gap between title and password prompt
- Add extra padding below password prompt to separate attempts line
- Keep attempts line flush with grid for cleaner layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9a5734348329b87668cc8a5868d7