### PR TITLE
feat: add bottom margin for attempt counter

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,7 +293,7 @@
   #content.hack-content{display:flex;flex-direction:column;justify-content:flex-start;padding:calc(4px * var(--scale));padding-bottom:calc(22px * var(--scale));}
   #header.hack-header{padding-top:calc(16px * var(--scale));padding-bottom:calc(4px * var(--scale));}
   #header.hack-header #hack-title{margin-top:0;margin-bottom:calc(2px * var(--scale));}
-  #header.hack-header #attempts{margin:0 0 calc(2px * var(--scale));}
+  #header.hack-header #attempts{margin:0 0 calc(4px + 2px * var(--scale));}
   #header.hack-header #attempts .attempt-block{display:inline-block;margin-right:calc(2px * var(--scale));}
   #header.hack-header #attempts .attempt-block:last-child{margin-right:0;}
     #header.hack-header #hack-warning{margin-bottom:calc(4px * var(--scale));}


### PR DESCRIPTION
## Summary
- adjust attempt counter styles to include extra 4px bottom margin

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bba0a9eba883298fddedc0684e3181