### PR TITLE
feat: add configurable commands tab and hacking support

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -140,6 +140,7 @@
 <form id="builder-form">
     <div class="mb-4 flex gap-2 border-b border-gray-300 dark:border-gray-700">
       <button type="button" @click="activeTab='content'" :class="['tab-btn', activeTab==='content' ? 'tab-btn-active' : '']">Terminal Content</button>
+      <button type="button" @click="activeTab='commands'" :class="['tab-btn', activeTab==='commands' ? 'tab-btn-active' : '']">Commands</button>
       <button type="button" @click="activeTab='hacking'" :class="['tab-btn', activeTab==='hacking' ? 'tab-btn-active' : '']">Hacking</button>
       <button type="button" @click="activeTab='prefs'" :class="['tab-btn', activeTab==='prefs' ? 'tab-btn-active' : '']">Preferences</button>
     </div>
@@ -203,6 +204,26 @@
         </template>
         <button type="button" @click="addScreen()" class="mt-2 px-2 py-1 border rounded">Add Screen</button>
       </div>
+    </fieldset>
+  </div>
+  <div v-show="activeTab==='commands'" class="space-y-4">
+    <fieldset class="p-4 border rounded-lg shadow">
+      <legend class="flex items-center gap-1">Built-in Commands</legend>
+      <ul class="list-disc ml-5">
+        <li v-for="c in builtIns" :key="c">{{ c }}</li>
+      </ul>
+    </fieldset>
+    <fieldset class="p-4 border rounded-lg shadow">
+      <legend class="flex items-center gap-1">Custom Commands</legend>
+      <div v-for="(cmd,idx) in commands" :key="cmd.uid" class="flex items-center flex-wrap gap-2 mb-2">
+        <input v-model="cmd.name" class="border rounded p-1 w-32" placeholder="Command">
+        <input v-model="cmd.screen" class="border rounded p-1 w-32" placeholder="Screen ID">
+        <input v-model="cmd.command" class="border rounded p-1 flex-1" placeholder="Response">
+        <label class="flex items-center gap-1"><input type="checkbox" v-model="cmd.help">Help</label>
+        <label class="flex items-center gap-1"><input type="checkbox" v-model="cmd.hacking">Hacking</label>
+        <button type="button" @click="removeCommand(idx)" class="action-btn">Delete</button>
+      </div>
+      <button type="button" @click="addCommand" class="mt-2 action-btn">Add Command</button>
     </fieldset>
   </div>
   <div v-show="activeTab==='hacking'" class="space-y-4">
@@ -303,6 +324,8 @@ const app = Vue.createApp({
     return {
         activeTab: 'content',
         screens: [],
+        commands: [],
+        builtIns:['back','help','?','syntaxhelper'],
         difficulties: [],
         difficultyChoice: 'Average',
         showDifficulties: false,
@@ -346,10 +369,16 @@ const app = Vue.createApp({
         this.screens.splice(idx,1);
         this.$nextTick(this.initSortables);
       },
-        addMenuItem(screen) {
-          screen.items.push({text:'', screen:'', command:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
-          this.$nextTick(this.initSortables);
-        },
+      addCommand() {
+        this.commands.push({name:'',screen:'',command:'',help:false,hacking:false,uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+      },
+      removeCommand(idx) {
+        this.commands.splice(idx,1);
+      },
+      addMenuItem(screen) {
+        screen.items.push({text:'', screen:'', command:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+        this.$nextTick(this.initSortables);
+      },
         removeMenuItem(sIdx, iIdx) {
           this.screens[sIdx].items.splice(iIdx,1);
           this.$nextTick(this.initSortables);
@@ -393,6 +422,7 @@ const app = Vue.createApp({
         document.getElementById('headers').value = (config.headerLines || []).join('\n');
         document.getElementById('boot-lines').value = (config.bootLines || []).join('\n');
         this.screens = [];
+        this.commands = [];
         const style = config.style || {};
         const globalText = style.textColor || DEFAULT_TEXT_COLOR;
         const globalBg = style.backgroundColor || DEFAULT_BG_COLOR;
@@ -426,6 +456,16 @@ const app = Vue.createApp({
           });
           if(!screen.items.length) screen.items.push({text:'', screen:'', command:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
           this.screens.push(screen);
+        });
+        Object.entries(config.commands || {}).forEach(([name, info])=>{
+          this.commands.push({
+            name,
+            screen: info.screen || '',
+            command: info.command || '',
+            help: !!info.help,
+            hacking: !!info.hacking,
+            uid: crypto.randomUUID?crypto.randomUUID():Math.random()
+          });
         });
         document.getElementById('locked').checked = config.locked || false;
         const diffs = config.hacking?.difficulties || defaultDifficulties;
@@ -476,6 +516,19 @@ const app = Vue.createApp({
         if(scr.borderColor !== borderColor) style.borderColor = scr.borderColor;
         screensObj[id] = Object.keys(style).length ? {items, style} : items;
       });
+      const commandsObj = {};
+      this.commands.forEach(c=>{
+        const name=(c.name||'').trim();
+        if(!name) return;
+        const screen=(c.screen||'').trim();
+        const message=(c.command||'').trim();
+        const obj={};
+        if(screen) obj.screen=screen;
+        if(message) obj.command=message;
+        if(c.help) obj.help=true;
+        if(c.hacking) obj.hacking=true;
+        if(Object.keys(obj).length) commandsObj[name]=obj;
+      });
       const diffValue = this.difficultyChoice;
       const difficulty = diffValue === 'Random' ? undefined : diffValue;
       const password = passwordEl.value.trim();
@@ -505,6 +558,7 @@ const app = Vue.createApp({
         locked,
         hacking
       };
+      if(Object.keys(commandsObj).length) config.commands = commandsObj;
       const blob = new Blob([JSON.stringify(config, null, 2)], {type: 'application/json'});
       const url = URL.createObjectURL(blob);
       const dl = document.getElementById('download-link');

--- a/config.json
+++ b/config.json
@@ -119,8 +119,12 @@
       "",
       "Use the Preferences button to adjust audio or typing speeds.",
       "",
-      { "text": "> RETURN", "screen": "menu" }
+    { "text": "> RETURN", "screen": "menu" }
     ]
+  },
+  "commands": {
+    "diagnostics": { "command": "Running system diagnostics...", "help": true },
+    "exit": { "screen": "menu", "help": true, "hacking": true }
   },
   "style": {
       "textColor": "#7aff7a",

--- a/index.html
+++ b/index.html
@@ -391,6 +391,7 @@ let headerLines=[];
 let bootLines=defaultBootLines;
 let screens={};
 let hacking={};
+let commands={};
 let startLocked=true;
 let baseStyle={textColor:'#7aff7a',backgroundColor:'#041204',borderColor:'#008800'};
 
@@ -446,6 +447,22 @@ async function loadConfig(cycle=currentCycle){
   bootLines = Array.isArray(cfg.bootLines) && cfg.bootLines.length ? cfg.bootLines : defaultBootLines;
   screens=cfg.screens || {};
   hacking = cfg.hacking || {};
+  commands={};
+  if(cfg.commands){
+    for(const [name,info] of Object.entries(cfg.commands)){
+      const key=name.toLowerCase();
+      commands[key]=info;
+      if(info.help){
+        if(!screens.help) screens.help=[];
+        const item={text:`> ${name}`};
+        if(info.screen) item.screen=info.screen;
+        if(info.command) item.command=info.command;
+        const helpItems=screens.help;
+        const retIdx=helpItems.findIndex(it=>typeof it==='object' && it.screen==='menu');
+        if(retIdx>=0) helpItems.splice(retIdx,0,item); else helpItems.push(item);
+      }
+    }
+  }
   if(savedUserSpeed===null && cfg.userSpeed!==undefined){
     userBaseSpeed=cfg.userSpeed;
     userSpeed=userBaseSpeed;
@@ -1099,6 +1116,17 @@ function clearResponses(){
   document.querySelectorAll('.response').forEach(el=>el.remove());
 }
 
+function executeCustomCommand(info){
+  if(info.screen){
+    showScreen(info.screen);
+    if(info.command){
+      requestAnimationFrame(()=>displayMessage(info.command));
+    }
+  }else if(info.command){
+    displayMessage(info.command);
+  }
+}
+
 function handleCommand(cmd){
   playEnterCharSound();
   clearResponses();
@@ -1116,16 +1144,33 @@ function handleCommand(cmd){
     }else{
       displayMessage('command unknown');
     }
-  }else if(hackingActive){
-    processGuess(cmd.trim().toUpperCase().slice(0,20),false);
-  }else if(command==='back'){
-    goBack();
-  }else if(command==='?'||command==='help'){
-    showScreen('help');
-  }else if(screens[command]){
-    showScreen(command);
   }else{
-    displayMessage('command unknown');
+    const custom=commands[command];
+    if(hackingActive){
+      if(custom && custom.hacking){
+        executeCustomCommand(custom);
+      }else{
+        processGuess(cmd.trim().toUpperCase().slice(0,20),false);
+      }
+    }else if(custom){
+      executeCustomCommand(custom);
+    }else if(command==='back'){
+      goBack();
+    }else if(command==='?'||command==='help'){
+      showScreen('help');
+    }else{
+      const match=currentOptions.find(o=>{
+        const text=o.textContent.trim().toLowerCase().replace(/^> ?/, '');
+        return text===command;
+      });
+      if(match){
+        match.click();
+      }else if(screens[command]){
+        showScreen(command);
+      }else{
+        displayMessage('command unknown');
+      }
+    }
   }
   input.textContent='';
   inputText='';
@@ -1574,10 +1619,13 @@ async function showScreen(name){
   let lines=[];
   let style=null;
   if(Array.isArray(data)){
-    lines=data;
+    lines=data.slice();
   }else if(data){
-    lines=data.items||[];
+    lines=(data.items||[]).slice();
     style=data.style||null;
+  }
+  if(name==='help'){
+    // no additional entries
   }
   applyScreenStyle(style);
   let i=0;


### PR DESCRIPTION
## Summary
- add Commands tab in builder with built-in command list and custom entries
- execute custom commands at runtime and allow opting into help and hacking screens
- include sample commands in default config

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bba86965048329a6691660d64920d9