### PR TITLE
feat: add boot customization and hacking header

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -140,6 +140,7 @@
 <form id="builder-form">
     <div class="mb-4 flex gap-2 border-b border-gray-300 dark:border-gray-700">
       <button type="button" @click="activeTab='content'" :class="['tab-btn', activeTab==='content' ? 'tab-btn-active' : '']">Terminal Content</button>
+      <button type="button" @click="activeTab='boot'" :class="['tab-btn', activeTab==='boot' ? 'tab-btn-active' : '']">Boot</button>
       <button type="button" @click="activeTab='commands'" :class="['tab-btn', activeTab==='commands' ? 'tab-btn-active' : '']">Commands</button>
       <button type="button" @click="activeTab='hacking'" :class="['tab-btn', activeTab==='hacking' ? 'tab-btn-active' : '']">Hacking</button>
       <button type="button" @click="activeTab='prefs'" :class="['tab-btn', activeTab==='prefs' ? 'tab-btn-active' : '']">Preferences</button>
@@ -152,10 +153,6 @@
     <fieldset class="p-4 border rounded-lg shadow" title="Enter header text shown beneath the title. Each line becomes its own header line. Example: 'Welcome to the RobCo Engineering Division Database!'.">
       <legend class="flex items-center gap-1">Headers</legend>
       <textarea id="headers" rows="4" cols="50" class="w-full p-2 border rounded" placeholder="Each line becomes a header line" title="Each line becomes a header line such as 'Welcome to the RobCo Engineering Division Database!'"></textarea>
-    </fieldset>
-    <fieldset class="p-4 border rounded-lg shadow" title="Lines shown during the boot sequence before titles appear. Each line becomes its own boot animation line. Example: 'Initializing Robco Industries (TM) MF Boot Agent v2.3.0'.">
-      <legend class="flex items-center gap-1">Boot Animation Text</legend>
-      <textarea id="boot-lines" rows="4" cols="50" class="w-full p-2 border rounded" placeholder="Each line becomes a boot line" title="Boot sequence lines such as 'RETROS BIOS' or 'Uppermem: 64 KB'"></textarea>
     </fieldset>
     <fieldset class="p-4 border rounded-lg shadow" title="Define screens and their menu options. Use screen IDs to link options to other screens or leave blank for plain text. Example: a 'help' screen with a RETURN option.">
       <legend class="flex items-center gap-1">Screens</legend>
@@ -206,6 +203,36 @@
       </div>
     </fieldset>
   </div>
+  <div v-show="activeTab==='boot'" class="space-y-4">
+    <fieldset class="p-4 border rounded-lg shadow">
+      <legend class="flex items-center gap-1">Boot Sequence</legend>
+      <div v-for="(step, idx) in bootSequence" :key="step.uid" class="flex items-center flex-wrap gap-1 mb-1">
+        <textarea v-model="step.text" rows="2" cols="40" class="border rounded p-1 flex-1" placeholder="Boot text"></textarea>
+        <select v-model="step.type" class="border rounded p-1">
+          <option value="terminal">Terminal</option>
+          <option value="user">User</option>
+        </select>
+        <button type="button" @click="moveBootStepUp(bootSequence, idx)" :disabled="idx===0" class="action-btn">▲</button>
+        <button type="button" @click="moveBootStepDown(bootSequence, idx)" :disabled="idx===bootSequence.length-1" class="action-btn">▼</button>
+        <button type="button" @click="removeBootStep(bootSequence, idx)" class="action-btn"><span class="w-4 h-4 flex items-center justify-center text-black dark:text-white">&times;</span></button>
+      </div>
+      <button type="button" @click="addBootStep(bootSequence)" class="mt-2 px-2 py-1 border rounded">Add Entry</button>
+    </fieldset>
+    <fieldset class="p-4 border rounded-lg shadow">
+      <legend class="flex items-center gap-1">Locked Boot Sequence</legend>
+      <div v-for="(step, idx) in lockedBootSequence" :key="step.uid" class="flex items-center flex-wrap gap-1 mb-1">
+        <textarea v-model="step.text" rows="2" cols="40" class="border rounded p-1 flex-1" placeholder="Boot text"></textarea>
+        <select v-model="step.type" class="border rounded p-1">
+          <option value="terminal">Terminal</option>
+          <option value="user">User</option>
+        </select>
+        <button type="button" @click="moveBootStepUp(lockedBootSequence, idx)" :disabled="idx===0" class="action-btn">▲</button>
+        <button type="button" @click="moveBootStepDown(lockedBootSequence, idx)" :disabled="idx===lockedBootSequence.length-1" class="action-btn">▼</button>
+        <button type="button" @click="removeBootStep(lockedBootSequence, idx)" class="action-btn"><span class="w-4 h-4 flex items-center justify-center text-black dark:text-white">&times;</span></button>
+      </div>
+      <button type="button" @click="addBootStep(lockedBootSequence)" class="mt-2 px-2 py-1 border rounded">Add Entry</button>
+    </fieldset>
+  </div>
   <div v-show="activeTab==='commands'" class="space-y-4">
     <fieldset class="p-4 border rounded-lg shadow">
       <legend class="flex items-center gap-1">Built-in Commands</legend>
@@ -239,6 +266,7 @@
       <label class="block" title="Maximum number of attempts allowed.">Max Attempts: <input type="number" id="max-attempts" min="1" value="4" class="ml-2 border rounded p-1 w-20"></label>
       <label class="block" title="Password needed to unlock the terminal after hacking, e.g., HARDWARE.">Password: <input type="text" id="password" class="ml-2 border rounded p-1"></label>
       <label class="block" title="Comma-separated words that will be removed as duds during hacking, e.g., RESEARCH, SCIENTIST.">Dud Words: <input type="text" id="dud-words" placeholder="WORD1, WORD2" class="ml-2 border rounded p-1"></label>
+      <label class="block" title="Header text shown at the top of the hacking screen.">Hacking Header: <input type="text" id="hacking-header-input" v-model="hackingHeader" class="ml-2 border rounded p-1"></label>
       <label class="block">Hacking Text Color:
         <input type="color" id="hack-text-color" class="ml-2" v-model="hackTextColor">
         <input type="text" id="hack-text-color-hex" class="ml-2 border rounded p-1 w-24" v-model="hackTextColor">
@@ -324,6 +352,8 @@ const app = Vue.createApp({
     return {
         activeTab: 'content',
         screens: [],
+        bootSequence:[{text:'',type:'terminal',uid:crypto.randomUUID?crypto.randomUUID():Math.random()}],
+        lockedBootSequence:[{text:'',type:'terminal',uid:crypto.randomUUID?crypto.randomUUID():Math.random()}],
         commands: [],
         builtIns:['back','help','?','syntaxhelper'],
         difficulties: [],
@@ -334,7 +364,8 @@ const app = Vue.createApp({
         borderColor: DEFAULT_BORDER_COLOR,
         hackTextColor: DEFAULT_TEXT_COLOR,
         hackBgColor: DEFAULT_BG_COLOR,
-        hackBorderColor: DEFAULT_BORDER_COLOR
+        hackBorderColor: DEFAULT_BORDER_COLOR,
+        hackingHeader: ''
       };
     },
   computed: {
@@ -407,6 +438,24 @@ const app = Vue.createApp({
           [items[iIdx], items[iIdx + 1]] = [items[iIdx + 1], items[iIdx]];
           this.$nextTick(this.initSortables);
         },
+        addBootStep(seq) {
+        seq.push({text:'', type:'terminal', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+        this.$nextTick(this.initSortables);
+        },
+        removeBootStep(seq, idx) {
+        seq.splice(idx,1);
+        this.$nextTick(this.initSortables);
+        },
+        moveBootStepUp(seq, idx) {
+        if(idx<=0) return;
+        [seq[idx-1], seq[idx]] = [seq[idx], seq[idx-1]];
+        this.$nextTick(this.initSortables);
+        },
+        moveBootStepDown(seq, idx) {
+        if(idx>=seq.length-1) return;
+        [seq[idx], seq[idx+1]] = [seq[idx+1], seq[idx]];
+        this.$nextTick(this.initSortables);
+        },
         initSortables() {
         },
       addDifficulty(d={name:'', wordCount:[1,1], length:[1,1]}) {
@@ -420,7 +469,10 @@ const app = Vue.createApp({
       loadConfig(config) {
         document.getElementById('titles').value = (config.titleLines || []).join('\n');
         document.getElementById('headers').value = (config.headerLines || []).join('\n');
-        document.getElementById('boot-lines').value = (config.bootLines || []).join('\n');
+        this.bootSequence = (config.bootSequence || []).map(s=>({...s, uid:crypto.randomUUID?crypto.randomUUID():Math.random()}));
+        this.lockedBootSequence = (config.lockedBootSequence || []).map(s=>({...s, uid:crypto.randomUUID?crypto.randomUUID():Math.random()}));
+        if(!this.bootSequence.length) this.bootSequence.push({text:'',type:'terminal',uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+        if(!this.lockedBootSequence.length) this.lockedBootSequence.push({text:'',type:'terminal',uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
         this.screens = [];
         this.commands = [];
         const style = config.style || {};
@@ -434,6 +486,7 @@ const app = Vue.createApp({
         this.hackTextColor = hackingStyle.textColor || globalText;
         this.hackBgColor = hackingStyle.backgroundColor || globalBg;
         this.hackBorderColor = hackingStyle.borderColor || globalBorder;
+        this.hackingHeader = (config.hacking && config.hacking.header) || '';
         Object.entries(config.screens || {}).forEach(([id, data]) => {
           const screen = {id, color:'#0c2c5f', items:[], open:true, uid:crypto.randomUUID?crypto.randomUUID():Math.random(), textColor:globalText, bgColor:globalBg, borderColor:globalBorder};
           const items = Array.isArray(data) ? data : (data.items || []);
@@ -487,8 +540,8 @@ const app = Vue.createApp({
       const titles = rawTitles.length === 1 && rawTitles[0] === '' ? [] : rawTitles;
       const rawHeaders = document.getElementById('headers').value.split('\n');
       const headers = rawHeaders.length === 1 && rawHeaders[0] === '' ? [] : rawHeaders;
-      const rawBoot = document.getElementById('boot-lines').value.split('\n');
-      const bootLines = rawBoot.length === 1 && rawBoot[0] === '' ? [] : rawBoot;
+      const bootSeq = this.bootSequence.filter(s=>s.text.trim()).map(s=>({text:s.text, type:s.type}));
+      const lockedBootSeq = this.lockedBootSequence.filter(s=>s.text.trim()).map(s=>({text:s.text, type:s.type}));
       const textColor = this.textColor || DEFAULT_TEXT_COLOR;
       const backgroundColor = this.bgColor || DEFAULT_BG_COLOR;
       const borderColor = this.borderColor || DEFAULT_BORDER_COLOR;
@@ -548,10 +601,12 @@ const app = Vue.createApp({
       if (!isNaN(maxAttempts) && maxAttempts !== 4) hacking.maxAttempts = maxAttempts;
       if (password) hacking.password = password;
       if (dudWords.length) hacking.dudWords = dudWords;
+      if (this.hackingHeader) hacking.header = this.hackingHeader;
       const config = {
         titleLines: titles,
         headerLines: headers,
-        bootLines,
+        bootSequence: bootSeq,
+        lockedBootSequence: lockedBootSeq,
         screens: screensObj,
         style,
         hackingStyle,

--- a/config.json
+++ b/config.json
@@ -10,14 +10,34 @@
     "How may I assist you this fine day?",
     "───────────────────────────────────────"
   ],
-  "bootLines": [
-    "Initializing Robco Industries (TM) MF Boot Agent v2.3.0",
-    "RETROS BIOS",
-    "RBIOS-4.02.08.00 52EE5.E7.E8",
-    "Copyright 2201-2203 Robco Ind.",
-    "Uppermem: 64 KB",
-    "Root (5A8)",
-    "Maintenance Mode"
+  "bootSequence": [
+    { "text": "Welcome to RobCo Industries (TM) Termlink", "type": "terminal" },
+    { "text": "", "type": "terminal" },
+    { "text": "Logon Admin", "type": "user" },
+    { "text": "", "type": "terminal" },
+    { "text": "Enter Password", "type": "terminal" },
+    { "text": "", "type": "terminal" },
+    { "text": "********", "type": "user" }
+  ],
+  "lockedBootSequence": [
+    { "text": "WELCOME TO ROBCO INDUSTRIES (TM) TERMLINK", "type": "terminal" },
+    { "text": "", "type": "terminal" },
+    { "text": "SET TERMINAL/INQUIRE", "type": "user" },
+    { "text": "", "type": "terminal" },
+    { "text": "RIT-V300", "type": "terminal" },
+    { "text": "", "type": "terminal" },
+    { "text": "SET FILE/PROTECTION=OWNER:RWED ACCOUNTS.F", "type": "user" },
+    { "text": "SET HALT RESTART/MAINT", "type": "user" },
+    { "text": "", "type": "terminal" },
+    { "text": "Initializing Robco Industries (TM) MF Boot Agent v2.3.0", "type": "terminal" },
+    { "text": "RETROS BIOS", "type": "terminal" },
+    { "text": "RBIOS-4.02.08.00 52EE5.E7.E8", "type": "terminal" },
+    { "text": "Copyright 2201-2203 Robco Ind.", "type": "terminal" },
+    { "text": "Uppermem: 64 KB", "type": "terminal" },
+    { "text": "Root (5A8)", "type": "terminal" },
+    { "text": "Maintenance Mode", "type": "terminal" },
+    { "text": "", "type": "terminal" },
+    { "text": "RUN DEBUG/ACCOUNTS.F", "type": "user" }
   ],
   "userSpeed": 75,
   "compSpeed": 90,
@@ -141,6 +161,7 @@
     "difficulty": "Average",
     "attempts": 4,
     "maxAttempts": 4,
+    "header": "ROBCO INDUSTRIES (TM) TERMLINK PROTOCOL",
     "difficulties": [
       { "name": "Very Easy", "wordCount": [8, 10], "length": [4, 5] },
       { "name": "Easy", "wordCount": [10, 12], "length": [6, 7] },

--- a/index.html
+++ b/index.html
@@ -377,18 +377,39 @@ window.addEventListener('resize',()=>{
   }
 });
 updateScale(prevWidth,prevHeight);
-const defaultBootLines=[
-  'Initializing Robco Industries (TM) MF Boot Agent v2.3.0',
-  'RETROS BIOS',
-  'RBIOS-4.02.08.00 52EE5.E7.E8',
-  'Copyright 2201-2203 Robco Ind.',
-  'Uppermem: 64 KB',
-  'Root (5A8)',
-  'Maintenance Mode'
+const defaultBootSequence=[
+  {type:'terminal',text:'Welcome to RobCo Industries (TM) Termlink'},
+  {type:'terminal',text:''},
+  {type:'user',text:'Logon Admin'},
+  {type:'terminal',text:''},
+  {type:'terminal',text:'Enter Password'},
+  {type:'terminal',text:''},
+  {type:'user',text:'********'}
+];
+const defaultLockedBootSequence=[
+  {type:'terminal',text:'WELCOME TO ROBCO INDUSTRIES (TM) TERMLINK'},
+  {type:'terminal',text:''},
+  {type:'user',text:'SET TERMINAL/INQUIRE'},
+  {type:'terminal',text:''},
+  {type:'terminal',text:'RIT-V300'},
+  {type:'terminal',text:''},
+  {type:'user',text:'SET FILE/PROTECTION=OWNER:RWED ACCOUNTS.F'},
+  {type:'user',text:'SET HALT RESTART/MAINT'},
+  {type:'terminal',text:''},
+  {type:'terminal',text:'Initializing Robco Industries (TM) MF Boot Agent v2.3.0'},
+  {type:'terminal',text:'RETROS BIOS'},
+  {type:'terminal',text:'RBIOS-4.02.08.00 52EE5.E7.E8'},
+  {type:'terminal',text:'Copyright 2201-2203 Robco Ind.'},
+  {type:'terminal',text:'Uppermem: 64 KB'},
+  {type:'terminal',text:'Root (5A8)'},
+  {type:'terminal',text:'Maintenance Mode'},
+  {type:'terminal',text:''},
+  {type:'user',text:'RUN DEBUG/ACCOUNTS.F'}
 ];
 let titleLines=[];
 let headerLines=[];
-let bootLines=defaultBootLines;
+let bootSequence=defaultBootSequence;
+let lockedBootSequence=defaultLockedBootSequence;
 let screens={};
 let hacking={};
 let commands={};
@@ -444,7 +465,8 @@ async function loadConfig(cycle=currentCycle){
   if(cycle!==currentCycle) return;
   titleLines=cfg.titleLines;
   headerLines=cfg.headerLines;
-  bootLines = Array.isArray(cfg.bootLines) && cfg.bootLines.length ? cfg.bootLines : defaultBootLines;
+  bootSequence = Array.isArray(cfg.bootSequence) && cfg.bootSequence.length ? cfg.bootSequence : defaultBootSequence;
+  lockedBootSequence = Array.isArray(cfg.lockedBootSequence) && cfg.lockedBootSequence.length ? cfg.lockedBootSequence : defaultLockedBootSequence;
   screens=cfg.screens || {};
   hacking = cfg.hacking || {};
   commands={};
@@ -864,7 +886,8 @@ async function renderHackScreen(){
   prompt.textContent='';
   attempts.textContent='';
   warning.textContent='';
-  await typeText(title,'ROBCO INDUSTRIES (TM) TERMLINK PROTOCOL');
+  const hackHeader=hacking.header || 'ROBCO INDUSTRIES (TM) TERMLINK PROTOCOL';
+  await typeText(title,hackHeader);
   title.textContent=title.textContent.trimEnd();
   await typeText(prompt,promptText);
   prompt.textContent=prompt.textContent.trimEnd();
@@ -1478,6 +1501,27 @@ async function init(cycle=currentCycle){
   }
 }
 
+async function playBootSequence(seq){
+  for(const step of seq){
+    if(step.text===''){
+      const br=document.createElement('br');
+      header.appendChild(br);
+      continue;
+    }
+    const div=document.createElement('div');
+    header.appendChild(div);
+    if(step.type==='user'){
+      div.textContent='>';
+      if(userSpeed<100) await sleep(1500);
+      await typeUserInput(div,step.text);
+    }else{
+      startScrollSound();
+      await typeText(div,step.text);
+      stopScrollSound();
+    }
+  }
+}
+
 async function showLockedBoot(){
   typing=true;
   resetSpeeds();
@@ -1487,62 +1531,7 @@ async function showLockedBoot(){
   header.classList.remove('hack-header');
   content.classList.remove('hack-content');
   leftAlignHeader();
-
-  startScrollSound();
-  const l1=document.createElement('div');
-  header.appendChild(l1);
-  await typeText(l1,'WELCOME TO ROBCO INDUSTRIES (TM) TERMLINK');
-  stopScrollSound();
-
-  const br0=document.createElement('br');
-  header.appendChild(br0);
-
-  const l2=document.createElement('div');
-  l2.textContent='>';
-  header.appendChild(l2);
-  if(userSpeed<100) await sleep(1500);
-  await typeUserInput(l2,'SET TERMINAL/INQUIRE');
-  const br1=document.createElement('br');
-  header.appendChild(br1);
-  startScrollSound();
-  const l3=document.createElement('div');
-  header.appendChild(l3);
-  await typeText(l3,'RIT-V300');
-  stopScrollSound();
-
-  const br2=document.createElement('br');
-  header.appendChild(br2);
-
-  const l4=document.createElement('div');
-  l4.textContent='>';
-  header.appendChild(l4);
-  if(userSpeed<100) await sleep(1500);
-  await typeUserInput(l4,'SET FILE/PROTECTION=OWNER:RWED ACCOUNTS.F');
-
-  const l5=document.createElement('div');
-  l5.textContent='>';
-  header.appendChild(l5);
-  if(userSpeed<100) await sleep(1500);
-  await typeUserInput(l5,'SET HALT RESTART/MAINT');
-  const br3=document.createElement('br');
-  header.appendChild(br3);
-  startScrollSound();
-  for(const text of bootLines){
-    const div=document.createElement('div');
-    header.appendChild(div);
-    await typeText(div,text);
-  }
-  stopScrollSound();
-
-  const br4=document.createElement('br');
-  header.appendChild(br4);
-
-  const lEnd=document.createElement('div');
-  lEnd.textContent='>';
-  header.appendChild(lEnd);
-  if(userSpeed<100) await sleep(1500);
-  await typeUserInput(lEnd,'RUN DEBUG/ACCOUNTS.F');
-
+  await playBootSequence(lockedBootSequence);
   typing=false;
 }
 
@@ -1555,32 +1544,7 @@ async function showBoot(){
   header.classList.remove('hack-header');
   content.classList.remove('hack-content');
   leftAlignHeader();
-  startScrollSound();
-  const line1=document.createElement('div');
-  header.appendChild(line1);
-  await typeText(line1,'Welcome to RobCo Industries (TM) Termlink');
-  stopScrollSound();
-  const brBoot1=document.createElement('br');
-  header.appendChild(brBoot1);
-  const line2=document.createElement('div');
-  line2.textContent='>';
-  header.appendChild(line2);
-  if(userSpeed<100) await sleep(1500);
-  await typeUserInput(line2,'Logon Admin');
-  const brBoot=document.createElement('br');
-  header.appendChild(brBoot);
-  const line3=document.createElement('div');
-  header.appendChild(line3);
-  startScrollSound();
-  await typeText(line3,'Enter Password');
-  stopScrollSound();
-  const brBoot2=document.createElement('br');
-  header.appendChild(brBoot2);
-  const line4=document.createElement('div');
-  line4.textContent='>';
-  header.appendChild(line4);
-  if(userSpeed<100) await sleep(1500);
-  await typeUserInput(line4,'*'.repeat(hackedPasswordLength));
+  await playBootSequence(bootSequence);
   if(userSpeed<100) await sleep(500);
   typing=false;
   await showIntro();


### PR DESCRIPTION
## Summary
- add Boot tab to builder with customizable boot and locked boot sequences
- allow editing hacking header and store in config
- support boot sequences and hacking header at runtime

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbce96d7e08329affa90588533e390