### PR TITLE
feat: allow editing of built-in commands

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -235,20 +235,16 @@
   </div>
   <div v-show="activeTab==='commands'" class="space-y-4">
     <fieldset class="p-4 border rounded-lg shadow">
-      <legend class="flex items-center gap-1">Built-in Commands</legend>
-      <ul class="list-disc ml-5">
-        <li v-for="c in builtIns" :key="c">{{ c }}</li>
-      </ul>
-    </fieldset>
-    <fieldset class="p-4 border rounded-lg shadow">
-      <legend class="flex items-center gap-1">Custom Commands</legend>
+      <legend class="flex items-center gap-1">Commands</legend>
       <div v-for="(cmd,idx) in commands" :key="cmd.uid" class="flex items-center flex-wrap gap-2 mb-2">
         <input v-model="cmd.name" class="border rounded p-1 w-32" placeholder="Command">
         <input v-model="cmd.screen" class="border rounded p-1 w-32" placeholder="Screen ID">
         <input v-model="cmd.command" class="border rounded p-1 flex-1" placeholder="Response">
         <label class="flex items-center gap-1"><input type="checkbox" v-model="cmd.help">Help</label>
         <label class="flex items-center gap-1"><input type="checkbox" v-model="cmd.hacking">Hacking</label>
-        <button type="button" @click="removeCommand(idx)" class="action-btn">Delete</button>
+        <button type="button" @click="moveCommandUp(idx)" :disabled="idx===0" class="mr-1 action-btn" title="Move up">▲</button>
+        <button type="button" @click="moveCommandDown(idx)" :disabled="idx===commands.length-1" class="mr-1 action-btn" title="Move down">▼</button>
+        <button type="button" @click="removeCommand(idx)" class="action-btn" title="Remove command"><span class="w-4 h-4 flex items-center justify-center text-black dark:text-white">&times;</span></button>
       </div>
       <button type="button" @click="addCommand" class="mt-2 action-btn">Add Command</button>
     </fieldset>
@@ -354,8 +350,14 @@ const app = Vue.createApp({
         screens: [],
         bootSequence:[{text:'',type:'terminal',uid:crypto.randomUUID?crypto.randomUUID():Math.random()}],
         lockedBootSequence:[{text:'',type:'terminal',uid:crypto.randomUUID?crypto.randomUUID():Math.random()}],
-        commands: [],
-        builtIns:['back','help','?','syntaxhelper'],
+        commands: [
+          {name:'back',screen:'',command:'',help:false,hacking:false,action:'back',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
+          {name:'help',screen:'',command:'',help:true,hacking:false,action:'help',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
+          {name:'?',screen:'',command:'',help:true,hacking:false,action:'help',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
+          {name:'syntaxhelper',screen:'',command:'',help:false,hacking:true,action:'syntaxhelper',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
+          {name:'ADMIN OVERRIDE',screen:'',command:'Access granted.',help:false,hacking:true,action:'adminoverride',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
+          {name:'ADMIN ALLOWANCES',screen:'',command:'Allowances set to 99.',help:false,hacking:true,action:'adminallowances',uid:crypto.randomUUID?crypto.randomUUID():Math.random()}
+        ],
         difficulties: [],
         difficultyChoice: 'Average',
         showDifficulties: false,
@@ -401,10 +403,20 @@ const app = Vue.createApp({
         this.$nextTick(this.initSortables);
       },
       addCommand() {
-        this.commands.push({name:'',screen:'',command:'',help:false,hacking:false,uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+        this.commands.push({name:'',screen:'',command:'',help:false,hacking:false,action:'',uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
       },
       removeCommand(idx) {
         this.commands.splice(idx,1);
+      },
+      moveCommandUp(idx) {
+        if (idx <= 0) return;
+        const arr = this.commands;
+        [arr[idx - 1], arr[idx]] = [arr[idx], arr[idx - 1]];
+      },
+      moveCommandDown(idx) {
+        if (idx >= this.commands.length - 1) return;
+        const arr = this.commands;
+        [arr[idx], arr[idx + 1]] = [arr[idx + 1], arr[idx]];
       },
       addMenuItem(screen) {
         screen.items.push({text:'', screen:'', command:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
@@ -517,6 +529,7 @@ const app = Vue.createApp({
             command: info.command || '',
             help: !!info.help,
             hacking: !!info.hacking,
+            action: info.action || '',
             uid: crypto.randomUUID?crypto.randomUUID():Math.random()
           });
         });
@@ -575,9 +588,11 @@ const app = Vue.createApp({
         if(!name) return;
         const screen=(c.screen||'').trim();
         const message=(c.command||'').trim();
+        const action=(c.action||'').trim();
         const obj={};
         if(screen) obj.screen=screen;
         if(message) obj.command=message;
+        if(action) obj.action=action;
         if(c.help) obj.help=true;
         if(c.hacking) obj.hacking=true;
         if(Object.keys(obj).length) commandsObj[name]=obj;

--- a/config.json
+++ b/config.json
@@ -143,6 +143,12 @@
     ]
   },
   "commands": {
+    "back": { "action": "back" },
+    "help": { "action": "help", "help": true },
+    "?": { "action": "help", "help": true },
+    "syntaxhelper": { "action": "syntaxhelper", "hacking": true },
+    "ADMIN OVERRIDE": { "action": "adminoverride", "command": "Access granted.", "hacking": true },
+    "ADMIN ALLOWANCES": { "action": "adminallowances", "command": "Allowances set to 99.", "hacking": true },
     "diagnostics": { "command": "Running system diagnostics...", "help": true },
     "exit": { "screen": "menu", "help": true, "hacking": true }
   },

--- a/index.html
+++ b/index.html
@@ -1021,66 +1021,97 @@ function insertHackBox(box){
   trimHackMessages();
 }
 
-function processGuess(guess,playSound=true){
-  if(!hackingActive) return;
-  guess=guess.trim().toUpperCase();
-  const override=guess==='ADMIN OVERRIDE';
-  const allowances=guess==='ADMIN ALLOWANCES';
-  const len=hackingData.password.length;
-  const box=document.createElement('div');
-  box.className='hack-message';
-  const guessLine=document.createElement('div');
-  guessLine.textContent=`>${override?'ADMIN OVERRIDE':allowances?'ADMIN ALLOWANCES':guess}`;
-  box.appendChild(guessLine);
-  if(playSound) playEnterCharSound();
-  if(allowances){
-    hackingData.attempts=99;
-    hackingData.maxAttempts=99;
-    updateAttempts();
-    const ok=document.createElement('div');
-    ok.textContent='Allowances set to 99.';
-    box.appendChild(ok);
-    insertHackBox(box);
-  }else if(override || guess===hackingData.password){
-    const likeLine=document.createElement('div');
-    likeLine.textContent=`${len}/${len} correct`;
-    box.appendChild(likeLine);
-    const ok=document.createElement('div');
-    ok.textContent='Access granted.';
-    box.appendChild(ok);
-    insertHackBox(box);
-    hackingActive=false;
-    hackingData.promptEl.textContent='';
-    hackingData.warningEl.textContent='';
-    hackingData.attemptsEl.textContent='';
-    playPasswordResult(true);
-    hackedPasswordLength=hackingData.password.length;
-    hasHacked=true;
-    setTrackedTimeout(()=>showIntro(),500);
-  }else{
-    let like=0;
-    for(let i=0;i<len;i++) if(guess[i]===hackingData.password[i]) like++;
-    const denied=document.createElement('div');
-    denied.textContent='Entry denied';
-    box.appendChild(denied);
-    const likeLine=document.createElement('div');
-    likeLine.textContent=`${like}/${len} correct`;
-    box.appendChild(likeLine);
-    insertHackBox(box);
-    hackingData.attempts--;
-    updateAttempts();
-    playPasswordResult(false);
-    if(hackingData.attempts<=0){
-      lockTerminal();
+  function processGuess(guess,playSound=true){
+    if(!hackingActive) return;
+    guess=guess.trim().toUpperCase();
+    const len=hackingData.password.length;
+    const box=document.createElement('div');
+    box.className='hack-message';
+    const guessLine=document.createElement('div');
+    guessLine.textContent=`>${guess}`;
+    box.appendChild(guessLine);
+    if(playSound) playEnterCharSound();
+    if(guess===hackingData.password){
+      const likeLine=document.createElement('div');
+      likeLine.textContent=`${len}/${len} correct`;
+      box.appendChild(likeLine);
+      const ok=document.createElement('div');
+      ok.textContent='Access granted.';
+      box.appendChild(ok);
+      insertHackBox(box);
+      hackingActive=false;
+      hackingData.promptEl.textContent='';
+      hackingData.warningEl.textContent='';
+      hackingData.attemptsEl.textContent='';
+      playPasswordResult(true);
+      hackedPasswordLength=hackingData.password.length;
+      hasHacked=true;
+      setTrackedTimeout(()=>showIntro(),500);
+    }else{
+      let like=0;
+      for(let i=0;i<len;i++) if(guess[i]===hackingData.password[i]) like++;
+      const denied=document.createElement('div');
+      denied.textContent='Entry denied';
+      box.appendChild(denied);
+      const likeLine=document.createElement('div');
+      likeLine.textContent=`${like}/${len} correct`;
+      box.appendChild(likeLine);
+      insertHackBox(box);
+      hackingData.attempts--;
+      updateAttempts();
+      playPasswordResult(false);
+      if(hackingData.attempts<=0){
+        lockTerminal();
+      }
     }
-  }
   input.textContent='';
   inputText='';
   updateInput();
   focusInput();
+  }
+
+function commandAdminAllowances(rawCmd, msg='Allowances set to 99.'){
+  const box=document.createElement('div');
+  box.className='hack-message';
+  const guessLine=document.createElement('div');
+  guessLine.textContent=`>${rawCmd.toUpperCase()}`;
+  box.appendChild(guessLine);
+  playEnterCharSound();
+  hackingData.attempts=99;
+  hackingData.maxAttempts=99;
+  updateAttempts();
+  const ok=document.createElement('div');
+  ok.textContent=msg;
+  box.appendChild(ok);
+  insertHackBox(box);
 }
 
-function addHackMessage(text){
+function commandAdminOverride(rawCmd, msg='Access granted.'){
+  const len=hackingData.password.length;
+  const box=document.createElement('div');
+  box.className='hack-message';
+  const guessLine=document.createElement('div');
+  guessLine.textContent=`>${rawCmd.toUpperCase()}`;
+  box.appendChild(guessLine);
+  playEnterCharSound();
+  const likeLine=document.createElement('div');
+  likeLine.textContent=`${len}/${len} correct`;
+  box.appendChild(likeLine);
+  const ok=document.createElement('div');
+  ok.textContent=msg;
+  box.appendChild(ok);
+  insertHackBox(box);
+  hackingActive=false;
+  hackingData.promptEl.textContent='';
+  hackingData.warningEl.textContent='';
+  hackingData.attemptsEl.textContent='';
+  playPasswordResult(true);
+  hackedPasswordLength=hackingData.password.length;
+  hasHacked=true;
+  setTrackedTimeout(()=>showIntro(),500);
+}
+
+  function addHackMessage(text){
   const box=document.createElement('div');
   box.className='hack-message';
   const line=document.createElement('div');
@@ -1163,6 +1194,53 @@ async function executeCustomCommand(info){
   }
 }
 
+async function executeCommand(info, rawCmd){
+  if(info.action){
+    switch(info.action){
+      case 'syntaxhelper':
+        if(hackingActive){
+          hackingData.grid.querySelectorAll('.bracket').forEach(span=>span.classList.add('highlight'));
+          setTrackedTimeout(()=>hackingData.grid.querySelectorAll('.bracket').forEach(span=>span.classList.remove('highlight')),1000);
+        }else if(info.command){
+          displayMessage(info.command);
+        }else{
+          displayMessage('command unknown');
+        }
+        break;
+      case 'back':
+        goBack();
+        if(info.command) displayMessage(info.command);
+        break;
+      case 'help':
+        await showScreen(info.screen || 'help');
+        if(info.command) displayMessage(info.command);
+        break;
+      case 'adminoverride':
+        if(hackingActive){
+          commandAdminOverride(rawCmd, info.command);
+        }else if(info.command){
+          displayMessage(info.command);
+        }else{
+          displayMessage('command unknown');
+        }
+        break;
+      case 'adminallowances':
+        if(hackingActive){
+          commandAdminAllowances(rawCmd, info.command);
+        }else if(info.command){
+          displayMessage(info.command);
+        }else{
+          displayMessage('command unknown');
+        }
+        break;
+      default:
+        await executeCustomCommand(info);
+    }
+  }else{
+    await executeCustomCommand(info);
+  }
+}
+
 async function handleCommand(cmd){
   if(typing) return;
   playEnterCharSound();
@@ -1173,40 +1251,28 @@ async function handleCommand(cmd){
     updateInput();
     return;
   }
-  const command=cmd.trim().toLowerCase();
-  if(command==='syntaxhelper'){
-    if(hackingActive){
-      hackingData.grid.querySelectorAll('.bracket').forEach(span=>span.classList.add('highlight'));
-      setTrackedTimeout(()=>hackingData.grid.querySelectorAll('.bracket').forEach(span=>span.classList.remove('highlight')),1000);
+  const raw=cmd.trim();
+  const command=raw.toLowerCase();
+  const custom=commands[command];
+  if(hackingActive){
+    if(custom && custom.hacking){
+      await executeCommand(custom, raw);
+    }else{
+      processGuess(raw.toUpperCase().slice(0,20),false);
+    }
+  }else if(custom){
+    await executeCommand(custom, raw);
+  }else{
+    const match=currentOptions.find(o=>{
+      const text=o.textContent.trim().toLowerCase().replace(/^> ?/, '');
+      return text===command;
+    });
+    if(match){
+      match.click();
+    }else if(screens[command]){
+      await showScreen(command);
     }else{
       displayMessage('command unknown');
-    }
-  }else{
-    const custom=commands[command];
-    if(hackingActive){
-      if(custom && custom.hacking){
-        await executeCustomCommand(custom);
-      }else{
-        processGuess(cmd.trim().toUpperCase().slice(0,20),false);
-      }
-    }else if(custom){
-      await executeCustomCommand(custom);
-    }else if(command==='back'){
-      goBack();
-    }else if(command==='?'||command==='help'){
-      await showScreen('help');
-    }else{
-      const match=currentOptions.find(o=>{
-        const text=o.textContent.trim().toLowerCase().replace(/^> ?/, '');
-        return text===command;
-      });
-      if(match){
-        match.click();
-      }else if(screens[command]){
-        await showScreen(command);
-      }else{
-        displayMessage('command unknown');
-      }
     }
   }
   input.textContent='';


### PR DESCRIPTION
## Summary
- make built-in commands like admin override and syntax helper editable and removable
- replace command delete buttons with arrow and cross controls
- handle built-in command actions through config-driven `action` property

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd1b0adac8329b6c22655b5d99ad7