### PR TITLE
feat: add builder shortcut

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -170,12 +170,13 @@
 <body class="m-0 p-4">
 <div id="builder-wrapper" class="max-w-4xl mx-auto">
 <h1 class="text-2xl font-bold mb-4">Config Builder</h1>
-<div class="mb-4 flex gap-2 items-center">
+<div class="mb-4 flex gap-2 items-center w-full">
   <button type="button" id="load-config" class="top-line-btn" title="Load configuration from a JSON file such as one previously exported.">Load Config</button>
   <button type="submit" form="builder-form" class="top-line-btn" title="Generate the configuration file and enable downloading config.json">Generate Config</button>
   <a id="download-link" class="hidden text-blue-600 underline" download="config.json">Download config.json</a>
   <span id="generate-feedback" class="text-green-600 hidden"></span>
   <button type="button" id="dark-toggle" class="top-line-btn" title="Toggle dark mode">Toggle Dark Mode</button>
+  <a href="index.html" class="top-line-btn ml-auto">Back to Terminal</a>
 </div>
 <input type="file" id="config-file" accept="application/json" class="hidden">
 <form id="builder-form">

--- a/index.html
+++ b/index.html
@@ -88,18 +88,18 @@
     align-items:center;
     justify-content:flex-end;
   }
-  #power-container, #config-container, #pref-container{
+  #power-container, #config-container, #pref-container, #builder-container{
     position:relative;
     display:flex;
     flex-direction:column;
     align-items:center;
   }
   #controls-container span{color:var(--text-color);}
-  #pref-container{
+  #pref-container, #builder-container{
     display:flex;
     margin-bottom:calc(10px * var(--scale));
   }
-  #pref-container span{
+  #pref-container span, #builder-container span{
     margin-top:calc(5px * var(--scale));
   }
   #pref-menu{
@@ -162,7 +162,7 @@
     left:50%;
     transform:translateX(-50%);
   }
-  #power-button, #config-button, #pref-button{
+  #power-button, #config-button, #pref-button, #builder-button{
     background:#b3410e;
     color:var(--text-color);
     border:calc(2px * var(--scale)) solid var(--border-color);
@@ -174,6 +174,9 @@
   }
   #config-button{
     background:#b8b20d;
+  }
+  #builder-button{
+    background:#0d8f0d;
   }
   #config-file{display:none;}
   #terminal::before,
@@ -314,6 +317,10 @@
     </div>
   </div>
   <div id="controls-container">
+    <div id="builder-container">
+      <a id="builder-button" href="builder.html" aria-label="Builder">&#x1F527;</a>
+      <span>Builder</span>
+    </div>
     <div id="pref-container">
       <button id="pref-button" aria-label="Preferences">&#9881;</button>
       <span>Prefs</span>


### PR DESCRIPTION
## Summary
- add green builder button linking to builder.html
- add Back to Terminal button within builder

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4dfe02648329bd0e7b35a9fea882