### PR TITLE
Center builder icon and fix power button on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,6 +171,9 @@
     border-radius:0;
     font-size:calc(20px * var(--scale) * 0.9);
     cursor:pointer;
+    display:flex;
+    align-items:center;
+    justify-content:center;
   }
   #config-button{
     background:#b8b20d;
@@ -1765,7 +1768,11 @@ document.addEventListener('keydown',e=>{
 });
 
 powerButton.addEventListener('click',async()=>{
-  await audioCtx.resume();
+  try{
+    await audioCtx.resume();
+  }catch(e){
+    console.warn('Audio context resume failed',e);
+  }
   if(!powered){
     currentCycle++;
     const cycle=currentCycle;


### PR DESCRIPTION
## Summary
- Center builder, power, config, and prefs button icons
- Prevent mobile power-button crash by handling AudioContext resume failure

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc525161a48329ad82afa68dadc801