### PR TITLE
Use inline SVG for power button icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -356,7 +356,12 @@
       <span>Holotape</span>
     </div>
     <div id="power-container">
-      <button id="power-button" aria-label="Power">&#x23FB;</button>
+      <button id="power-button" aria-label="Power">
+        <svg width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M12 2v10"/>
+          <path d="M6.3 6.3a8 8 0 1 0 11.4 0"/>
+        </svg>
+      </button>
       <span>Power</span>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Replace Unicode power glyph with inline SVG to ensure the Power button renders on mobile

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc55878a708329ad809c9f07d71b2e