### PR TITLE
Play select sound before leaving builder

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -215,7 +215,7 @@
   <a id="download-link" class="hidden text-blue-600 underline" download="config.json">Download config.json</a>
   <span id="generate-feedback" class="text-green-600 hidden"></span>
   <button type="button" id="dark-toggle" class="top-line-btn" title="Toggle dark mode">Toggle Dark Mode</button>
-  <a href="index.html" class="top-line-btn ml-auto">Back to Terminal</a>
+  <a id="back-to-terminal" href="index.html" class="top-line-btn ml-auto">Back to Terminal</a>
 </div>
 <input type="file" id="config-file" accept="application/json" class="hidden">
 <form id="builder-form">
@@ -820,8 +820,22 @@ darkToggle.addEventListener('click',()=>{
 document.addEventListener('click',e=>{
   const btn=e.target.closest('button, a.top-line-btn');
   if(!btn) return;
-  if(btn.id==='dark-toggle' || btn.classList.contains('tab-btn')) return;
+  if(btn.id==='dark-toggle' || btn.classList.contains('tab-btn') || btn.id==='back-to-terminal') return;
   playSound('Pip/select3.wav');
+});
+
+// Preload select sound to reduce latency
+const backSelectPreload=new Audio('Pip/select3.wav');
+backSelectPreload.preload='auto';
+backSelectPreload.load();
+
+// Play select sound and navigate after it finishes
+document.getElementById('back-to-terminal').addEventListener('click',e=>{
+  e.preventDefault();
+  const audio=playSound('Pip/select3.wav');
+  const go=()=>{ window.location.href='index.html'; };
+  audio.addEventListener('ended',go,{once:true});
+  setTimeout(go,150);
 });
 
 const passwordEl = document.getElementById('password');


### PR DESCRIPTION
## Summary
- add unique back link id and handler that plays select sound before navigating
- preload select sound to reduce playback latency

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68bcc8dc1110832995f7aef413bcbf93