### PR TITLE
Move generate feedback status outside toolbar

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -213,10 +213,10 @@
   <button type="button" id="load-config" class="top-line-btn" title="Load configuration from a JSON file such as one previously exported.">Load Config</button>
   <button type="submit" form="builder-form" class="top-line-btn" title="Generate the configuration file and enable downloading config.json">Generate Config</button>
   <a id="download-link" class="hidden text-blue-600 underline" download="config.json">Download config.json</a>
-  <span id="generate-feedback" class="text-green-600 hidden"></span>
   <button type="button" id="dark-toggle" class="top-line-btn" title="Toggle dark mode">Toggle Dark Mode</button>
   <a id="back-to-terminal" href="index.html" class="top-line-btn ml-auto">Back to Terminal</a>
 </div>
+<div id="generate-feedback" class="text-green-600 hidden mt-2"></div>
 <input type="file" id="config-file" accept="application/json" class="hidden">
 <form id="builder-form">
     <div id="tabs-bar" class="mb-4 flex gap-2 border-b border-gray-300 dark:border-gray-700">


### PR DESCRIPTION
## Summary
- place `generate-feedback` in its own block below the top action bar so it no longer affects button alignment

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd5b17f848329847ca27f56826354