### PR TITLE
Persist terminal session state

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,6 +130,21 @@
     color:var(--text-color);
     border:calc(1px * var(--scale)) solid var(--border-color);
   }
+  #pref-menu button{
+    margin-top:calc(5px * var(--scale));
+    background:var(--terminal-bg);
+    color:var(--text-color);
+    border:calc(1px * var(--scale)) solid var(--border-color);
+    padding:calc(4px * var(--scale)) calc(6px * var(--scale));
+    font:inherit;
+    letter-spacing:inherit;
+    cursor:pointer;
+  }
+  #pref-menu button:hover,
+  #pref-menu button:focus{
+    background:var(--border-color);
+    color:var(--terminal-bg);
+  }
   #pref-menu input[type=range]{
     margin-left:calc(5px * var(--scale));
     -webkit-appearance:none;
@@ -348,6 +363,7 @@
             <option value="95">Fast</option>
           </select>
         </label>
+        <button type="button" id="reset-session-button">Reset Session</button>
       </div>
     </div>
     <div id="config-container">
@@ -614,6 +630,7 @@ let userSpeed=userBaseSpeed;
 let compSpeed=compBaseSpeed;
 let inputText="";
 let screenHistory=[];
+let currentScreenName=null;
 let skipNextClick=false;
 const MAX_INPUT_CHARS=64;
 let hackingActive=false;
@@ -621,6 +638,9 @@ let hackingData=null;
 let terminalLocked=false;
 let hasHacked=false;
 let hackedPasswordLength=0;
+const SESSION_STATE_KEY='terminalSessionState';
+let restoringSession=false;
+let skipNextSessionSave=false;
 
 function resetSpeeds(){
   userSpeed=userBaseSpeed;
@@ -646,6 +666,80 @@ function leftAlignHeader(){
   header.style.textAlign='left';
 }
 
+function getSessionSnapshot(){
+  const currentScreen=currentScreenName || (screenHistory.length?screenHistory[screenHistory.length-1]:null);
+  if(!currentScreen) return null;
+  return {
+    screenHistory:screenHistory.slice(),
+    currentScreen,
+    inputText,
+    options:currentOptions.map(opt=>opt.textContent.trim())
+  };
+}
+
+function persistSessionState(){
+  if(restoringSession) return;
+  if(skipNextSessionSave){
+    skipNextSessionSave=false;
+    return;
+  }
+  const snapshot=getSessionSnapshot();
+  if(!snapshot) return;
+  try{
+    localStorage.setItem(SESSION_STATE_KEY,JSON.stringify(snapshot));
+  }catch(err){
+    console.warn('Failed to save session state',err);
+  }
+}
+
+function loadPersistedSessionState(){
+  try{
+    const raw=localStorage.getItem(SESSION_STATE_KEY);
+    if(!raw) return null;
+    return JSON.parse(raw);
+  }catch(err){
+    console.warn('Failed to load session state',err);
+    return null;
+  }
+}
+
+function clearPersistedSessionState(){
+  try{
+    localStorage.removeItem(SESSION_STATE_KEY);
+  }catch(err){
+    console.warn('Failed to clear session state',err);
+  }
+}
+
+async function restoreSessionStateIfAvailable(){
+  const saved=loadPersistedSessionState();
+  if(!saved || !saved.currentScreen) return false;
+  if(typeof saved.currentScreen!=='string') return false;
+  if(saved.screenHistory && !Array.isArray(saved.screenHistory)) return false;
+  if(saved.currentScreen && !screens[saved.currentScreen]) return false;
+  const history=Array.isArray(saved.screenHistory)?saved.screenHistory.slice():[];
+  screenHistory=history.length?history.slice(0,-1):[];
+  let restored=false;
+  restoringSession=true;
+  try{
+    await showScreen(saved.currentScreen);
+    input.textContent=saved.inputText||'';
+    inputText=saved.inputText||'';
+    updateInput();
+    restored=true;
+  }catch(err){
+    console.warn('Failed to restore session state',err);
+    screenHistory=[];
+    currentScreenName=null;
+  }finally{
+    restoringSession=false;
+  }
+  if(!restored) return false;
+  focusInput();
+  persistSessionState();
+  return true;
+}
+
 function applyScreenStyle(style){
   const t=style&&style.textColor?style.textColor:baseStyle.textColor;
   const b=style&&style.backgroundColor?style.backgroundColor:baseStyle.backgroundColor;
@@ -664,6 +758,7 @@ const focusSlider=document.getElementById('focus-volume');
 const selectSlider=document.getElementById('select-volume');
 const userSpeedSelect=document.getElementById('user-speed-select');
 const compSpeedSelect=document.getElementById('comp-speed-select');
+const resetSessionButton=document.getElementById('reset-session-button');
 const builderButton=document.getElementById('builder-button');
 
 prefButton.addEventListener('click',()=>{
@@ -679,6 +774,18 @@ builderButton.addEventListener('click',e=>{
   audio.play();
   audio.addEventListener('ended',()=>{window.location.href=builderButton.href;});
 });
+
+if(resetSessionButton){
+  resetSessionButton.addEventListener('click',()=>{
+    skipNextSessionSave=true;
+    clearPersistedSessionState();
+    prefMenu.style.display='none';
+    if(powered){
+      displayMessage('Session reset.');
+      focusInput();
+    }
+  });
+}
 
 let humVolume=Math.pow(humSlider.value/100,2);
 let scrollVolume=scrollSlider.value/100;
@@ -747,6 +854,7 @@ function updateInput(){
   input.textContent=text;
   inputText=text;
   placeCaretAtEnd(input);
+  persistSessionState();
 }
 updateInput();
 loadConfig();
@@ -1356,6 +1464,7 @@ async function handleCommand(cmd){
   inputText='';
   updateInput();
   focusInput();
+  persistSessionState();
 }
 
 const audioCtx=new (window.AudioContext||window.webkitAudioContext)();
@@ -1698,6 +1807,7 @@ async function showScreen(name){
   centerHeader();
   clearResponses();
   screenHistory.push(name);
+  currentScreenName=name;
   inputText='';
   input.textContent='';
   updateInput();
@@ -1778,6 +1888,7 @@ async function showScreen(name){
       }
     }
   }
+  persistSessionState();
 }
 
 document.addEventListener('keydown',e=>{
@@ -1829,6 +1940,7 @@ powerButton.addEventListener('click',async()=>{
       header.innerHTML='';
       content.innerHTML='';
       screenHistory=[];
+      currentScreenName=null;
       currentOptions=[];
       selected=-1;
       inputText='';
@@ -1837,7 +1949,12 @@ powerButton.addEventListener('click',async()=>{
       hackingActive=false;
       hackingData=null;
       await loadConfig(cycle);
-      loadScrollSound().then(()=>{if(currentCycle===cycle) init(cycle);});
+      const restored=await restoreSessionStateIfAvailable();
+      if(!restored){
+        loadScrollSound().then(()=>{if(currentCycle===cycle) init(cycle);});
+      }else{
+        loadScrollSound();
+      }
     }
     powered=true;
   }else{
@@ -1847,7 +1964,9 @@ powerButton.addEventListener('click',async()=>{
     clearAllTimeouts();
     cancelWaits();
     typing=false;
+    persistSessionState();
     screenHistory=[];
+    currentScreenName=null;
     currentOptions=[];
     selected=-1;
     inputText='';


### PR DESCRIPTION
## Summary
- persist terminal session state (screen history, input text, available options) in localStorage
- restore the saved session during power on and provide a reset control in the preferences menu

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c89f3c6bb88329aaab795c75cf79a1