### PR TITLE
Add custom audio support for menu items and commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,43 @@ If you power off the terminal you can choose a different file and power on
 again to reload with the new configuration.
 
 
+## Per-item audio cues
+
+Every interactive entry in a screen can define optional `hoverSound` and
+`selectSound` properties. These values point to audio files (relative to the
+HTML page) that should play when the item is highlighted or activated. Commands
+can also specify the same properties so that typing a command triggers custom
+audio before its output appears. When the sounds are omitted, the terminal falls
+back to its default focus and select effects.
+
+Example menu item:
+
+```json
+{
+  "text": "> Initiate Launch Sequence",
+  "command": "Launch parameters locked in.",
+  "hoverSound": "Pip/Highlight4.wav",
+  "selectSound": "Terminal 3/passgood.wav"
+}
+```
+
+Example command entry:
+
+```json
+"diagnostics": {
+  "command": "Running system diagnostics...",
+  "help": true,
+  "selectSound": "Terminal 3/passgood.wav"
+}
+```
+
+The builder interface exposes these properties through the new **Select sound**
+and **Hover sound** inputs shown beside each menu item and command. Enter a
+relative or absolute URL to the audio clip you want to use; the builder exports
+the values directly into `config.json`, and the terminal preloads and plays the
+clips when needed.
+
+
 ## Optional Passwords and Dud Words
 
 The hacking mini-game can be customized by providing a `password` and optional

--- a/builder.html
+++ b/builder.html
@@ -271,6 +271,8 @@
                   <textarea v-model="item.text" rows="2" cols="30" class="menu-text mr-1 border rounded p-1 flex-1" placeholder="Menu text"></textarea>
                   <input v-model="item.screen" class="menu-screen mr-1 border rounded p-1 w-24" placeholder="Screen id">
                   <input v-model="item.command" class="menu-command mr-1 border rounded p-1 w-32" placeholder="Command">
+                  <input v-model="item.selectSound" class="menu-select-sound mr-1 border rounded p-1 w-36" placeholder="Select sound">
+                  <input v-model="item.hoverSound" class="menu-hover-sound mr-1 border rounded p-1 w-36" placeholder="Hover sound">
                   <button type="button" @click="moveMenuItemUp(sIdx, iIdx)" :disabled="iIdx===0" class="mr-1 action-btn" title="Move up">▲</button>
                   <button type="button" @click="moveMenuItemDown(sIdx, iIdx)" :disabled="iIdx===screen.items.length-1" class="mr-1 action-btn" title="Move down">▼</button>
                     <button type="button" @click="removeMenuItem(sIdx, iIdx)" class="action-btn" title="Remove item"><span class="w-4 h-4 flex items-center justify-center delete-icon">&times;</span></button>
@@ -321,6 +323,8 @@
         <input v-model="cmd.name" class="border rounded p-1 w-32" placeholder="Command">
         <input v-model="cmd.screen" class="border rounded p-1 w-32" placeholder="Screen ID">
         <input v-model="cmd.command" class="border rounded p-1 w-32" placeholder="Response">
+        <input v-model="cmd.selectSound" class="border rounded p-1 w-36" placeholder="Select sound">
+        <input v-model="cmd.hoverSound" class="border rounded p-1 w-36" placeholder="Hover sound">
         <label class="flex items-center gap-1"><input type="checkbox" v-model="cmd.help">Help</label>
         <label class="flex items-center gap-1"><input type="checkbox" v-model="cmd.hacking">Hacking</label>
         <div class="flex gap-1">
@@ -434,12 +438,12 @@ const app = Vue.createApp({
         bootSequence:[{text:'',type:'terminal',uid:crypto.randomUUID?crypto.randomUUID():Math.random()}],
         lockedBootSequence:[{text:'',type:'terminal',uid:crypto.randomUUID?crypto.randomUUID():Math.random()}],
         commands: [
-          {name:'back',screen:'',command:'',help:false,hacking:false,action:'back',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
-          {name:'help',screen:'',command:'',help:true,hacking:false,action:'help',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
-          {name:'?',screen:'',command:'',help:true,hacking:false,action:'help',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
-          {name:'syntaxhelper',screen:'',command:'',help:false,hacking:true,action:'syntaxhelper',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
-          {name:'ADMIN OVERRIDE',screen:'',command:'Access granted.',help:false,hacking:true,action:'adminoverride',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
-          {name:'ADMIN ALLOWANCES',screen:'',command:'Allowances set to 99.',help:false,hacking:true,action:'adminallowances',uid:crypto.randomUUID?crypto.randomUUID():Math.random()}
+          {name:'back',screen:'',command:'',help:false,hacking:false,action:'back',selectSound:'',hoverSound:'',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
+          {name:'help',screen:'',command:'',help:true,hacking:false,action:'help',selectSound:'',hoverSound:'',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
+          {name:'?',screen:'',command:'',help:true,hacking:false,action:'help',selectSound:'',hoverSound:'',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
+          {name:'syntaxhelper',screen:'',command:'',help:false,hacking:true,action:'syntaxhelper',selectSound:'',hoverSound:'',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
+          {name:'ADMIN OVERRIDE',screen:'',command:'Access granted.',help:false,hacking:true,action:'adminoverride',selectSound:'',hoverSound:'',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
+          {name:'ADMIN ALLOWANCES',screen:'',command:'Allowances set to 99.',help:false,hacking:true,action:'adminallowances',selectSound:'',hoverSound:'',uid:crypto.randomUUID?crypto.randomUUID():Math.random()}
         ],
         difficulties: [],
         difficultyChoice: 'Average',
@@ -483,7 +487,7 @@ const app = Vue.createApp({
         this.screens.push({
           id,
           color,
-          items:[{text:'', screen:'', command:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()}],
+          items:[{text:'', screen:'', command:'', selectSound:'', hoverSound:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()}],
           open:true,
           uid:crypto.randomUUID?crypto.randomUUID():Math.random(),
           textColor:text,
@@ -497,7 +501,7 @@ const app = Vue.createApp({
         this.$nextTick(this.initSortables);
       },
       addCommand() {
-        this.commands.push({name:'',screen:'',command:'',help:false,hacking:false,action:'',uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+        this.commands.push({name:'',screen:'',command:'',help:false,hacking:false,action:'',selectSound:'',hoverSound:'',uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
       },
       removeCommand(idx) {
         this.commands.splice(idx,1);
@@ -513,7 +517,7 @@ const app = Vue.createApp({
         [arr[idx], arr[idx + 1]] = [arr[idx + 1], arr[idx]];
       },
       addMenuItem(screen) {
-        screen.items.push({text:'', screen:'', command:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+        screen.items.push({text:'', screen:'', command:'', selectSound:'', hoverSound:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
         this.$nextTick(this.initSortables);
       },
         removeMenuItem(sIdx, iIdx) {
@@ -603,17 +607,19 @@ const app = Vue.createApp({
           }
           items.forEach(item=>{
             if (typeof item === 'string') {
-              screen.items.push({text:item, screen:'', command:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+              screen.items.push({text:item, screen:'', command:'', selectSound:'', hoverSound:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
             } else {
               screen.items.push({
                 text: item.text || '',
                 screen: item.screen || '',
                 command: item.command || '',
+                selectSound: item.selectSound || '',
+                hoverSound: item.hoverSound || '',
                 uid: crypto.randomUUID?crypto.randomUUID():Math.random()
               });
             }
           });
-          if(!screen.items.length) screen.items.push({text:'', screen:'', command:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+          if(!screen.items.length) screen.items.push({text:'', screen:'', command:'', selectSound:'', hoverSound:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
           this.screens.push(screen);
         });
         Object.entries(config.commands || {}).forEach(([name, info])=>{
@@ -624,6 +630,8 @@ const app = Vue.createApp({
             help: !!info.help,
             hacking: !!info.hacking,
             action: info.action || '',
+            selectSound: info.selectSound || '',
+            hoverSound: info.hoverSound || '',
             uid: crypto.randomUUID?crypto.randomUUID():Math.random()
           });
         });
@@ -664,11 +672,20 @@ const app = Vue.createApp({
           const text=(it.text||'').trimEnd();
           const screen=(it.screen||'').trim();
           const command=(it.command||'').trim();
-          if(!text && !screen && !command) return;
-          if(screen && command){ items.push({text,screen,command}); }
-          else if(screen){ items.push({text,screen}); }
-          else if(command){ items.push({text,command}); }
-          else { items.push(text); }
+          const selectSound=(it.selectSound||'').trim();
+          const hoverSound=(it.hoverSound||'').trim();
+          if(!text && !screen && !command && !selectSound && !hoverSound) return;
+          const needsObject=!!(screen || command || selectSound || hoverSound);
+          if(needsObject){
+            const obj={text};
+            if(screen) obj.screen=screen;
+            if(command) obj.command=command;
+            if(selectSound) obj.selectSound=selectSound;
+            if(hoverSound) obj.hoverSound=hoverSound;
+            items.push(obj);
+          }else{
+            items.push(text);
+          }
         });
         const style = {};
         if(scr.textColor !== textColor) style.textColor = scr.textColor;
@@ -683,12 +700,16 @@ const app = Vue.createApp({
         const screen=(c.screen||'').trim();
         const message=(c.command||'').trim();
         const action=(c.action||'').trim();
+        const selectSound=(c.selectSound||'').trim();
+        const hoverSound=(c.hoverSound||'').trim();
         const obj={};
         if(screen) obj.screen=screen;
         if(message) obj.command=message;
         if(action) obj.action=action;
         if(c.help) obj.help=true;
         if(c.hacking) obj.hacking=true;
+        if(selectSound) obj.selectSound=selectSound;
+        if(hoverSound) obj.hoverSound=hoverSound;
         if(Object.keys(obj).length) commandsObj[name]=obj;
       });
       const diffValue = this.difficultyChoice;

--- a/config.json
+++ b/config.json
@@ -43,12 +43,12 @@
   "compSpeed": 90,
   "screens": {
     "menu": [
-      { "text": "> Protectron Schematics", "screen": "protectron" },
+      { "text": "> Protectron Schematics", "screen": "protectron", "hoverSound": "Pip/Highlight4.wav", "selectSound": "Pip/select3.wav" },
       { "text": "> Mr. Handy Service Records", "screen": "handy" },
       { "text": "> Assaultron Combat Models", "screen": "assaultron" },
       { "text": "> Securitron Systems Control", "screen": "securitron" },
       { "text": "> Turret Controls", "screen": "turret" },
-      { "text": "> Run Protectron Maintenance Mode", "command": "Maintenance mode Engaged" },
+      { "text": "> Run Protectron Maintenance Mode", "command": "Maintenance mode Engaged", "selectSound": "Terminal 3/passgood.wav" },
       { "text": "> Experimental Robotics Files", "screen": "experimental" },
       "",
       ""
@@ -149,7 +149,7 @@
     "syntaxhelper": { "action": "syntaxhelper", "hacking": true },
     "ADMIN OVERRIDE": { "action": "adminoverride", "command": "Access granted.", "hacking": true },
     "ADMIN ALLOWANCES": { "action": "adminallowances", "command": "Allowances set to 99.", "hacking": true },
-    "diagnostics": { "command": "Running system diagnostics...", "help": true },
+    "diagnostics": { "command": "Running system diagnostics...", "help": true, "selectSound": "Terminal 3/passgood.wav" },
     "exit": { "screen": "menu", "help": true, "hacking": true }
   },
   "style": {

--- a/index.html
+++ b/index.html
@@ -470,11 +470,24 @@ function trackAudio(audio){
 }
 
 const preloadedAudios=[];
+const customAudioCache=new Map();
 
 function preloadAudio(src){
   const audio=new Audio(src);
   audio.preload='auto';
   preloadedAudios.push(audio);
+  return audio;
+}
+
+function preloadCustomAudio(src){
+  if(typeof src!=='string') return null;
+  const key=src.trim();
+  if(!key) return null;
+  if(customAudioCache.has(key)) return customAudioCache.get(key);
+  const audio=new Audio(key);
+  audio.preload='auto';
+  preloadedAudios.push(audio);
+  customAudioCache.set(key,audio);
   return audio;
 }
 
@@ -484,6 +497,25 @@ function playCachedAudio(audio,volume){
   audio.volume=volume;
   audio.play();
   audio.addEventListener('ended',()=>activeAudios.delete(audio),{once:true});
+}
+
+function playCustomSound(src,volume){
+  if(!powered) return false;
+  if(typeof src!=='string') return false;
+  const key=src.trim();
+  if(!key) return false;
+  const audio=preloadCustomAudio(key);
+  if(!audio) return false;
+  playCachedAudio(audio,volume);
+  return true;
+}
+
+function playCustomHoverSound(src){
+  return playCustomSound(src,focusVolume);
+}
+
+function playCustomSelectSound(src){
+  return playCustomSound(src,selectVolume);
 }
 
 async function resumePreloadedAudio(){
@@ -541,6 +573,8 @@ async function loadConfig(cycle=currentCycle){
         const item={text:`> ${name}`};
         if(info.screen) item.screen=info.screen;
         if(info.command) item.command=info.command;
+        if(info.selectSound) item.selectSound=info.selectSound;
+        if(info.hoverSound) item.hoverSound=info.hoverSound;
         const helpItems=screens.help;
         const retIdx=helpItems.findIndex(it=>typeof it==='object' && it.screen==='menu');
         if(retIdx>=0) helpItems.splice(retIdx,0,item); else helpItems.push(item);
@@ -577,6 +611,32 @@ async function loadConfig(cycle=currentCycle){
   };
   startLocked=cfg.locked!==undefined?cfg.locked:true;
   if(hasHacked) startLocked=false;
+  preloadConfigAudio();
+}
+
+function preloadConfigAudio(){
+  const sources=new Set();
+  if(screens && typeof screens==='object'){
+    for(const data of Object.values(screens)){
+      const items=Array.isArray(data)?data:((data&&data.items)||[]);
+      if(!items) continue;
+      for(const item of items){
+        if(item && typeof item==='object'){
+          if(typeof item.selectSound==='string' && item.selectSound.trim()) sources.add(item.selectSound.trim());
+          if(typeof item.hoverSound==='string' && item.hoverSound.trim()) sources.add(item.hoverSound.trim());
+        }
+      }
+    }
+  }
+  for(const info of Object.values(commands||{})){
+    if(info && typeof info==='object'){
+      if(typeof info.selectSound==='string' && info.selectSound.trim()) sources.add(info.selectSound.trim());
+      if(typeof info.hoverSound==='string' && info.hoverSound.trim()) sources.add(info.hoverSound.trim());
+    }
+  }
+  for(const src of sources){
+    preloadCustomAudio(src);
+  }
 }
 
 const terminal=document.getElementById('terminal');
@@ -1368,6 +1428,7 @@ function clearResponses(){
 }
 
 async function executeCustomCommand(info){
+  ensureSelectSound(info);
   if(info.screen){
     await showScreen(info.screen);
     if(info.command){
@@ -1383,6 +1444,7 @@ async function executeCommand(info, rawCmd){
   if(info.action){
     switch(info.action){
       case 'syntaxhelper':
+        ensureSelectSound(info);
         if(hackingActive){
           hackingData.grid.querySelectorAll('.bracket').forEach(span=>span.classList.add('highlight'));
           setTrackedTimeout(()=>hackingData.grid.querySelectorAll('.bracket').forEach(span=>span.classList.remove('highlight')),1000);
@@ -1393,14 +1455,17 @@ async function executeCommand(info, rawCmd){
         }
         break;
       case 'back':
+        ensureSelectSound(info);
         goBack();
         if(info.command) displayMessage(info.command);
         break;
       case 'help':
+        ensureSelectSound(info);
         await showScreen(info.screen || 'help');
         if(info.command) displayMessage(info.command);
         break;
       case 'adminoverride':
+        ensureSelectSound(info);
         if(hackingActive){
           commandAdminOverride(rawCmd, info.command);
         }else if(info.command){
@@ -1410,6 +1475,7 @@ async function executeCommand(info, rawCmd){
         }
         break;
       case 'adminallowances':
+        ensureSelectSound(info);
         if(hackingActive){
           commandAdminAllowances(rawCmd, info.command);
         }else if(info.command){
@@ -1577,6 +1643,15 @@ function playSelectSound(){
   const enterAudio=trackAudio(new Audio(enterSrc));
   enterAudio.volume=selectVolume;
   enterAudio.play();
+}
+
+function ensureSelectSound(info){
+  const src=info && typeof info.selectSound==='string'?info.selectSound.trim():'';
+  if(src){
+    if(playCustomSelectSound(src)) return true;
+  }
+  playSelectSound();
+  return false;
 }
 
 function playCharFocusSound(){
@@ -1839,9 +1914,14 @@ async function showScreen(name){
       if(typeof line==='object'){
         div.className='option';
         div.tabIndex=0;
+        const hoverSound=typeof line.hoverSound==='string'?line.hoverSound.trim():'';
+        const selectSound=typeof line.selectSound==='string'?line.selectSound.trim():'';
+        if(hoverSound) div.dataset.hoverSound=hoverSound; else delete div.dataset.hoverSound;
+        if(selectSound) div.dataset.selectSound=selectSound; else delete div.dataset.selectSound;
         await typeText(div,line.text);
         div.addEventListener('click',async()=>{
-          playSelectSound();
+          const sound=div.dataset.selectSound||'';
+          if(!playCustomSelectSound(sound)) playSelectSound();
           if(line.screen){
             await showScreen(line.screen);
             if(line.command){
@@ -1857,7 +1937,8 @@ async function showScreen(name){
             currentOptions[selected].classList.remove('selected');
             selected=-1;
           }
-          playFocusSound();
+          const sound=div.dataset.hoverSound||'';
+          if(!playCustomHoverSound(sound)) playFocusSound();
         });
         currentOptions.push(div);
       }else{
@@ -1898,13 +1979,15 @@ document.addEventListener('keydown',e=>{
     selected=selected<0?0:(selected+1)%currentOptions.length;
     currentOptions[selected].classList.add('selected');
     currentOptions[selected].focus();
-    playFocusSound();
+    const sound=currentOptions[selected].dataset.hoverSound||'';
+    if(!playCustomHoverSound(sound)) playFocusSound();
   }else if(e.key==='ArrowUp'){
     if(selected>=0) currentOptions[selected].classList.remove('selected');
     selected=selected<0?currentOptions.length-1:(selected-1+currentOptions.length)%currentOptions.length;
     currentOptions[selected].classList.add('selected');
     currentOptions[selected].focus();
-    playFocusSound();
+    const sound=currentOptions[selected].dataset.hoverSound||'';
+    if(!playCustomHoverSound(sound)) playFocusSound();
   }else if(e.key==='Enter' && selected>=0){
     currentOptions[selected].click();
   }


### PR DESCRIPTION
## Summary
- add select and hover sound inputs to the builder and include the fields when importing or exporting configuration data
- preload custom audio paths from the configuration and honor per-item select/hover sounds when rendering screens or running commands
- document the new configuration properties and update the sample config to demonstrate their usage

## Testing
- python -m json.tool config.json

------
https://chatgpt.com/codex/tasks/task_e_68c8a2fc19e08329b8372ce438c5b8f2