### PR TITLE
Improve builder screen accents and layout

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -72,6 +72,16 @@
       transition: transform 0.2s;
       touch-action: none;
     }
+    .screen {
+      color: #000000;
+    }
+    .menu-item {
+      color: inherit;
+    }
+    .dark .screen,
+    .dark .menu-item {
+      color: var(--screen-text-color, var(--text-color));
+    }
     .drag-chosen {
       transform: scale(1.05);
       box-shadow: 0 4px 8px rgba(0,0,0,0.2);
@@ -266,7 +276,7 @@
   </div>
   <div id="download-panel" class="hidden mt-4">
     <div class="download-box">
-      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div class="flex flex-col gap-2">
         <a
           id="download-link"
           :class="['top-line-btn download-btn w-full sm:w-auto', downloadUrl ? '' : 'hidden']"
@@ -276,7 +286,12 @@
         >
           Download {{ downloadFileName }}
         </a>
-        <div id="generate-feedback" class="text-green-600 hidden text-sm sm:text-base sm:text-right w-full sm:w-auto"></div>
+        <div
+          id="generate-feedback"
+          class="text-green-600 hidden text-sm sm:text-base text-left w-full"
+          role="status"
+          aria-live="polite"
+        ></div>
       </div>
     </div>
   </div>
@@ -301,7 +316,11 @@
       <legend class="flex items-center gap-1">Screens</legend>
       <div id="screens-container">
         <template v-for="(screen, sIdx) in screens">
-            <div :key="screen.uid" class="screen mb-4 border border-l-4 rounded p-2" :style="{borderColor: screen.color, backgroundColor: screen.color, color: screen.textColor}">
+            <div
+              :key="screen.uid"
+              class="screen mb-4 border border-l-4 rounded p-2"
+              :style="{ borderColor: screen.color, backgroundColor: screen.color, '--screen-text-color': screen.textColor || textColor }"
+            >
             <div class="mb-2">
               <div class="flex flex-wrap items-center mb-2">
                 <button type="button" @click="screen.open = !screen.open" class="mr-2 action-btn" :aria-expanded="screen.open">{{screen.open ? '▼' : '►' }}</button>
@@ -329,7 +348,11 @@
             </div>
             <div v-show="screen.open" class="pl-6 items-container" :data-sidx="sIdx" :id="'items-'+screen.uid">
               <template v-for="(item, iIdx) in screen.items">
-                <div :key="item.uid" class="menu-item mb-1 flex flex-wrap items-center gap-1 border p-1 rounded" :style="{backgroundColor: screen.color, borderColor: screen.color, color: screen.textColor}">
+                <div
+                  :key="item.uid"
+                  class="menu-item mb-1 flex flex-wrap items-center gap-1 border p-1 rounded"
+                  :style="{ backgroundColor: screen.color, borderColor: screen.color, '--screen-text-color': screen.textColor || textColor }"
+                >
                   <textarea v-model="item.text" rows="2" cols="30" class="menu-text mr-1 border rounded p-1 flex-1" placeholder="Menu text"></textarea>
                   <input
                     v-model="item.screen"
@@ -510,19 +533,98 @@ function buildDownloadFileName(name){
   return base;
 }
 
-// Adjust the base color by a given amount and introduce a slight random
-// variation in each channel so that successive screens are easier to
-// differentiate.
-function shadeColor(col, amt) {
-  const num = parseInt(col.slice(1), 16);
-  const vary = () => Math.floor(Math.random() * 30) - 15; // -15 to +14
-  let r = (num >> 16) + amt + vary();
-  let g = (num >> 8 & 0x00ff) + amt + vary();
-  let b = (num & 0x0000ff) + amt + vary();
-  r = Math.max(0, Math.min(255, r));
-  g = Math.max(0, Math.min(255, g));
-  b = Math.max(0, Math.min(255, b));
-  return '#' + (r << 16 | g << 8 | b).toString(16).padStart(6, '0');
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function hexToHsl(hex) {
+  let normalized = (hex || '').toString().trim();
+  if (normalized.startsWith('#')) {
+    normalized = normalized.slice(1);
+  }
+  if (normalized.length === 3) {
+    normalized = normalized.split('').map(ch => ch + ch).join('');
+  }
+  if (!/^[0-9a-f]{6}$/i.test(normalized)) {
+    return { h: 210, s: 60, l: 30 };
+  }
+  const r = parseInt(normalized.slice(0, 2), 16) / 255;
+  const g = parseInt(normalized.slice(2, 4), 16) / 255;
+  const b = parseInt(normalized.slice(4, 6), 16) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      default:
+        h = (r - g) / d + 4;
+        break;
+    }
+    h *= 60;
+  }
+
+  return { h, s: s * 100, l: l * 100 };
+}
+
+function hslToHex(h, s, l) {
+  h = ((h % 360) + 360) % 360;
+  s = clamp(s, 0, 100) / 100;
+  l = clamp(l, 0, 100) / 100;
+
+  const hue2rgb = (p, q, t) => {
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 1 / 2) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
+  };
+
+  let r;
+  let g;
+  let b;
+  if (s === 0) {
+    r = g = b = l;
+  } else {
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    const hk = h / 360;
+    r = hue2rgb(p, q, hk + 1 / 3);
+    g = hue2rgb(p, q, hk);
+    b = hue2rgb(p, q, hk - 1 / 3);
+  }
+
+  return '#' + [r, g, b].map(v => Math.round(v * 255).toString(16).padStart(2, '0')).join('');
+}
+
+// Generate screen accent colors by rotating hue and adjusting saturation/lightness.
+function generateScreenColor(baseHex, index) {
+  const base = hexToHsl(baseHex);
+  const hueStep = 37;
+  const lightCycle = [0, 6, -4, 12, -2, 8];
+  const satCycle = [0, -6, 5, -8, 7, -4];
+  const baseLightness = base.l + 28;
+  const baseSaturation = clamp(base.s, 45, 75);
+  const jitter = () => Math.random() * 4 - 2;
+  const hueJitter = () => Math.random() * 6 - 3;
+
+  const hue = (base.h + index * hueStep + hueJitter() + 360) % 360;
+  const lightness = clamp(baseLightness + lightCycle[index % lightCycle.length] + jitter(), 32, 82);
+  const saturation = clamp(baseSaturation + satCycle[index % satCycle.length] + jitter(), 38, 78);
+
+  const color = hslToHex(hue, saturation, lightness);
+  return /^#[0-9a-f]{6}$/i.test(color) ? color : baseHex;
 }
 
 const app = Vue.createApp({
@@ -810,9 +912,8 @@ const app = Vue.createApp({
         const text = this.textColor || DEFAULT_TEXT_COLOR;
         const bg = this.bgColor || DEFAULT_BG_COLOR;
         const border = this.borderColor || DEFAULT_BORDER_COLOR;
-        // Use a larger offset to make the shade differences more pronounced.
-        const offset = (this.screens.length % 10) * 20;
-        const color = shadeColor(BASE_SCREEN_COLOR, offset);
+        const index = this.screens.length;
+        const color = generateScreenColor(BASE_SCREEN_COLOR, index);
         this.screens.push({
           id,
           color,
@@ -941,7 +1042,8 @@ const app = Vue.createApp({
           this.hackingHeader = (config.hacking && config.hacking.header) || '';
           this.customSoundDir = typeof config.customSoundDir === 'string' ? config.customSoundDir : '';
           Object.entries(config.screens || {}).forEach(([id, data]) => {
-            const screen = {id, color:'#0c2c5f', items:[], open:true, uid:crypto.randomUUID?crypto.randomUUID():Math.random(), textColor:globalText, bgColor:globalBg, borderColor:globalBorder};
+            const color = generateScreenColor(BASE_SCREEN_COLOR, this.screens.length);
+            const screen = {id, color, items:[], open:true, uid:crypto.randomUUID?crypto.randomUUID():Math.random(), textColor:globalText, bgColor:globalBg, borderColor:globalBorder};
             const items = Array.isArray(data) ? data : (data.items || []);
             if(!Array.isArray(data) && data.style){
               if(data.style.textColor) screen.textColor = data.style.textColor;


### PR DESCRIPTION
## Summary
- ensure screen cards keep black text in light mode while respecting configured colors in dark mode
- move the generated file timestamp beneath the download button and expose it as status text
- generate varied-hue screen accent colors when adding or loading screens for clearer differentiation

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68c9e3318e348329b17e274d2453a9f6