### PR TITLE
Clear unsaved flag when navigation confirmed

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -1130,7 +1130,11 @@ const app = Vue.createApp({
       confirmNavigation(message){
         if(!this.hasUnsavedChanges) return true;
         const prompt = message || 'You have unsaved changes. Continue without exporting your configuration?';
-        return window.confirm(prompt);
+        const confirmed = window.confirm(prompt);
+        if(confirmed){
+          this.hasUnsavedChanges = false;
+        }
+        return confirmed;
       },
       handleBackToTerminal(event){
         if(event && (event.metaKey || event.ctrlKey || event.shiftKey || event.button === 1)){


### PR DESCRIPTION
## Summary
- reset the unsaved changes flag when navigation is confirmed to avoid duplicate prompts

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68ca3e9c888883298ce2727e932158c5