### PR TITLE
Add configurable sound overrides and builder tab

### DIFF
--- a/builder - working.html
+++ b/builder - working.html
@@ -1,0 +1,1460 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+  <meta charset="UTF-8">
+  <title>Terminal Config Builder</title>
+  <script>
+    window.tailwind = window.tailwind || {};
+    window.tailwind.config = { darkMode: 'class' };
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
+  <script src="builder-utils.js"></script>
+  <style>
+    @font-face{
+      font-family:"FSEX300";
+      src:url("fonts/FSEX300.ttf") format("truetype");
+      font-weight:normal;
+      font-style:normal;
+    }
+    :root{
+      --text-color:#7aff7a;
+      --terminal-bg:#041204;
+      --border-color:#008800;
+    }
+    body {
+      background-color:#f9fafb;
+      color:#000;
+      font-family:"FSEX300","IBM Plex Mono",ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Courier New",monospace;
+      background-image:repeating-linear-gradient(
+        rgba(0,0,0,0.05) 0px,
+        rgba(0,0,0,0.05) 1px,
+        transparent 1px,
+        transparent 4px
+      );
+    }
+    .dark body {
+      background:var(--terminal-bg);
+      color:var(--text-color);
+      background-image:repeating-linear-gradient(
+        rgba(0,0,0,0.55) 0px,
+        rgba(0,0,0,0.55) 1px,
+        transparent 1px,
+        transparent 4px
+      );
+    }
+    fieldset {
+      background-color:#f3f4f6;
+      border:2px solid #d1d5db;
+    }
+    .dark fieldset {
+      background-color:var(--terminal-bg);
+      border:2px solid var(--border-color);
+    }
+    input, textarea, select {
+      background-color:#f9fafb;
+      border:2px solid #d1d5db;
+      color:#000;
+    }
+    .dark input, .dark textarea, .dark select {
+      background-color:transparent;
+      border:2px solid var(--border-color);
+      color:var(--text-color);
+    }
+    ::placeholder {
+      color: #4b5563;
+      opacity: 1;
+    }
+    .dark ::placeholder {
+      color: rgba(122,255,122,0.5);
+    }
+    .screen, .menu-item, .difficulty-item {
+      transition: transform 0.2s;
+      touch-action: none;
+    }
+    .screen {
+      color: #000000;
+    }
+    .menu-item {
+      color: inherit;
+    }
+    .dark .screen,
+    .dark .menu-item {
+      color: var(--screen-text-color, var(--text-color));
+    }
+    .drag-chosen {
+      transform: scale(1.05);
+      box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+    }
+    .drag-ghost {
+      opacity: 0.4;
+      border: 2px dashed #d1d5db;
+    }
+    .dark .drag-ghost {
+      border: 2px dashed var(--border-color);
+    }
+    .dragging {
+      user-select: none;
+    }
+    .invalid-field {
+      border-color:#dc2626 !important;
+      box-shadow:0 0 0 1px rgba(220,38,38,0.6);
+    }
+    .dark .invalid-field {
+      border-color:#f87171 !important;
+      box-shadow:0 0 0 1px rgba(248,113,113,0.7);
+    }
+      .action-btn {
+        border:2px solid #9ca3af;
+        border-radius:0.25rem;
+        padding:0 0.25rem;
+        background-color:#f3f4f6;
+        color:#000;
+      }
+      .action-btn:hover {
+        background-color: #e5e7eb;
+      }
+      .dark .action-btn {
+        border:2px solid var(--border-color);
+        background-color: var(--terminal-bg);
+        color: var(--text-color);
+        text-shadow:0 0 5px rgba(122,255,122,0.5);
+      }
+    .dark .action-btn:hover {
+      background-color:#0a1f0a;
+    }
+    .top-line-btn {
+      padding: 0.25rem 0.5rem;
+      border: 2px solid #4b5563;
+      border-radius: 0.25rem;
+      background-color: #f3f4f6;
+      color: #000000;
+      cursor: pointer;
+    }
+    .top-line-btn:hover {
+      background-color: #e5e7eb;
+    }
+    .dark .top-line-btn {
+      border:2px solid var(--border-color);
+      background-color: var(--terminal-bg);
+      color: var(--text-color);
+      text-shadow:0 0 5px rgba(122,255,122,0.5);
+    }
+    .dark .top-line-btn:hover {
+      background-color:#0a1f0a;
+    }
+    .delete-icon{ color:#000; }
+    .dark .delete-icon{ color:var(--text-color); }
+
+    .tab-btn {
+      padding: 0.25rem 0.5rem;
+      border: 2px solid #4b5563;
+      border-bottom-width: 2px;
+      border-radius: 0.25rem 0.25rem 0 0;
+      background-color: #f3f4f6;
+      color: #000000;
+      cursor: pointer;
+    }
+    .tab-btn:hover {
+      background-color: #e5e7eb;
+    }
+    .tab-btn-active {
+      background-color: #ffffff;
+      border-bottom-color: transparent;
+      margin-bottom: -2px;
+    }
+    .dark .tab-btn {
+      border:2px solid var(--border-color);
+      border-bottom-color: var(--border-color);
+      background-color: var(--terminal-bg);
+      color: var(--text-color);
+      text-shadow:0 0 5px rgba(122,255,122,0.5);
+      border-radius:0;
+    }
+    .dark .tab-btn:hover {
+      background-color:#0a1f0a;
+    }
+    .dark .tab-btn-active {
+      background-color:#0a1f0a;
+      border-bottom-color: var(--terminal-bg);
+      margin-bottom:-2px;
+    }
+
+    .dark #builder-wrapper {
+      border:4px solid var(--border-color);
+      border-radius:12px;
+      padding:1rem;
+      background:var(--terminal-bg);
+      background-image:repeating-linear-gradient(
+        rgba(0,0,0,0.55) 0px,
+        rgba(0,0,0,0.55) 1px,
+        transparent 1px,
+        transparent 4px
+      );
+      box-shadow:0 0 10px rgba(0,255,0,0.2);
+    }
+    .dark #tabs-bar { border-bottom:2px solid var(--border-color); }
+    .dark a { color: var(--text-color); }
+    .dark #generate-feedback { color: var(--text-color); }
+    #download-panel .download-box {
+      border:2px solid #4b5563;
+      background-color:#f3f4f6;
+      border-radius:0.5rem;
+      padding:1rem;
+      box-shadow:0 4px 12px rgba(0,0,0,0.2);
+    }
+    .dark #download-panel .download-box {
+      border:2px solid var(--border-color);
+      background-color:rgba(4,18,4,0.85);
+      box-shadow:0 0 12px rgba(0,255,0,0.25);
+    }
+    .download-box .download-btn {
+      white-space:normal;
+      text-align:center;
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+      padding:0.5rem 1.25rem;
+      font-weight:600;
+      max-width:100%;
+      min-width:0;
+      overflow-wrap:anywhere;
+      word-break:break-word;
+    }
+    @media (min-width: 640px) {
+      #download-panel .download-box > .flex {
+        flex-wrap: wrap;
+      }
+      #download-panel .download-box #generate-feedback {
+        flex: 0 0 auto;
+        min-width: 0;
+        max-width: 100%;
+      }
+    }
+
+    /* Boot sequence reveal */
+    #builder-wrapper.boot-load {
+      overflow:hidden;
+      animation:boot-reveal 2s steps(25,end) forwards;
+      clip-path:inset(0 0 100% 0);
+    }
+    @keyframes boot-reveal {
+      to { clip-path:inset(0 0 0 0); }
+    }
+
+      /* UI shake effect */
+      #builder-wrapper.shake {
+        animation:ui-shake 0.35s cubic-bezier(.36,.07,.19,.97);
+      }
+      @keyframes ui-shake {
+        0% { transform:translateX(0); }
+        10% { transform:translateX(-12px); }
+        20% { transform:translateX(12px); }
+        30% { transform:translateX(-16px); }
+        40% { transform:translateX(16px); }
+        50% { transform:translateX(-12px); }
+        60% { transform:translateX(12px); }
+        70% { transform:translateX(-8px); }
+        80% { transform:translateX(8px); }
+        90% { transform:translateX(-4px); }
+        100% { transform:translateX(0); }
+      }
+  </style>
+</head>
+<body class="m-0 p-4">
+<div id="builder-wrapper" class="max-w-4xl mx-auto">
+<h1 class="text-2xl font-bold mb-4">Config Builder</h1>
+<form id="builder-form">
+  <div class="mb-4 flex gap-2 items-center w-full flex-wrap">
+    <button type="button" id="load-config" class="top-line-btn" title="Load configuration from a JSON file such as one previously exported.">Load Config</button>
+    <label for="download-name" class="flex items-center gap-2" title="Name used for the generated JSON file. The .json extension is added automatically.">
+      File Name:
+      <input id="download-name" v-model="downloadName" class="border rounded p-1 w-40" placeholder="config">
+    </label>
+    <button type="submit" class="top-line-btn" title="Generate the configuration file and enable downloading the JSON.">Generate Config</button>
+    <button type="button" id="dark-toggle" class="top-line-btn" title="Toggle dark mode">Toggle Dark Mode</button>
+    <a id="back-to-terminal" href="index.html" class="top-line-btn ml-auto" @click="handleBackToTerminal">Back to Terminal</a>
+  </div>
+  <div id="download-panel" class="hidden mt-4">
+    <div class="download-box">
+      <div class="flex flex-col gap-2">
+        <a
+          id="download-link"
+          :class="['top-line-btn download-btn w-full sm:w-auto', downloadUrl ? '' : 'hidden']"
+          :download="downloadFileName"
+          :href="downloadUrl"
+          @click="handleDownloadClick"
+        >
+          Download {{ downloadFileName }}
+        </a>
+        <div
+          id="generate-feedback"
+          class="text-green-600 hidden text-sm sm:text-base text-left self-start max-w-full inline-flex flex-wrap"
+          role="status"
+          aria-live="polite"
+        ></div>
+      </div>
+    </div>
+  </div>
+  <input type="file" id="config-file" accept="application/json" class="hidden">
+    <div id="tabs-bar" class="mb-4 flex gap-2 border-b border-gray-300 dark:border-gray-700">
+      <button type="button" @click="activeTab='content'" :class="['tab-btn', activeTab==='content' ? 'tab-btn-active' : '']">Terminal Content</button>
+      <button type="button" @click="activeTab='boot'" :class="['tab-btn', activeTab==='boot' ? 'tab-btn-active' : '']">Boot</button>
+      <button type="button" @click="activeTab='commands'" :class="['tab-btn', activeTab==='commands' ? 'tab-btn-active' : '']">Commands</button>
+      <button type="button" @click="activeTab='hacking'" :class="['tab-btn', activeTab==='hacking' ? 'tab-btn-active' : '']">Hacking</button>
+      <button type="button" @click="activeTab='prefs'" :class="['tab-btn', activeTab==='prefs' ? 'tab-btn-active' : '']">Preferences</button>
+    </div>
+  <div v-show="activeTab==='content'" class="space-y-4 tab-content">
+    <fieldset class="p-4 border rounded-lg shadow" title="Enter the lines displayed at the top of the terminal. Each line becomes a separate title line. Example: 'ROBCO INDUSTRIES UNIFIED OPERATING SYSTEM'.">
+      <legend class="flex items-center gap-1">Titles</legend>
+      <textarea id="titles" rows="4" cols="50" class="w-full p-2 border rounded" placeholder="Each line becomes a title line" title="Each line becomes a title line, e.g., ROBCO INDUSTRIES UNIFIED OPERATING SYSTEM"></textarea>
+    </fieldset>
+    <fieldset class="p-4 border rounded-lg shadow" title="Enter header text shown beneath the title. Each line becomes its own header line. Example: 'Welcome to the RobCo Engineering Division Database!'.">
+      <legend class="flex items-center gap-1">Headers</legend>
+      <textarea id="headers" rows="4" cols="50" class="w-full p-2 border rounded" placeholder="Each line becomes a header line" title="Each line becomes a header line such as 'Welcome to the RobCo Engineering Division Database!'"></textarea>
+    </fieldset>
+    <fieldset class="p-4 border rounded-lg shadow" title="Define screens and their menu options. Use screen IDs to link options to other screens or leave blank for plain text. Example: a 'help' screen with a RETURN option.">
+      <legend class="flex items-center gap-1">Screens</legend>
+      <div id="screens-container">
+        <template v-for="(screen, sIdx) in screens">
+            <div
+              :key="screen.uid"
+              class="screen mb-4 border border-l-4 rounded p-2"
+              :style="{ borderColor: screen.color, backgroundColor: screen.color, '--screen-text-color': screen.textColor || textColor }"
+            >
+            <div class="mb-2">
+              <div class="flex flex-wrap items-center mb-2">
+                <button type="button" @click="screen.open = !screen.open" class="mr-2 action-btn" :aria-expanded="screen.open">{{screen.open ? '▼' : '►' }}</button>
+                <input v-model="screen.id" class="screen-id flex-1 border rounded p-1 mr-2" placeholder="Screen ID">
+                <input type="color" v-model="screen.color" class="screen-color w-8 h-8 p-0 border-2 rounded mr-2 shadow cursor-pointer" title="Color is for organization only and does not affect terminal appearance">
+                <input type="text" v-model="screen.color" class="w-20 p-1 border rounded mr-2" title="Color is for organization only and does not affect terminal appearance">
+                <button type="button" @click="moveScreenUp(sIdx)" :disabled="sIdx===0" class="mr-1 action-btn" title="Move up">▲</button>
+                <button type="button" @click="moveScreenDown(sIdx)" :disabled="sIdx===screens.length-1" class="mr-1 action-btn" title="Move down">▼</button>
+                  <button type="button" @click="removeScreen(sIdx)" class="action-btn" title="Remove screen"><span class="w-4 h-4 flex items-center justify-center delete-icon">&times;</span></button>
+              </div>
+              <div class="flex flex-wrap items-center">
+                <label class="flex items-center mr-2">Text:
+                  <input type="color" v-model="screen.textColor" class="ml-1">
+                  <input type="text" v-model="screen.textColor" class="ml-1 border rounded p-1 w-24">
+                </label>
+                <label class="flex items-center mr-2">Background:
+                  <input type="color" v-model="screen.bgColor" class="ml-1">
+                  <input type="text" v-model="screen.bgColor" class="ml-1 border rounded p-1 w-24">
+                </label>
+                <label class="flex items-center mr-2">Border:
+                  <input type="color" v-model="screen.borderColor" class="ml-1">
+                  <input type="text" v-model="screen.borderColor" class="ml-1 border rounded p-1 w-24">
+                </label>
+              </div>
+            </div>
+            <div v-show="screen.open" class="pl-6 items-container" :data-sidx="sIdx" :id="'items-'+screen.uid">
+              <template v-for="(item, iIdx) in screen.items">
+                <div
+                  :key="item.uid"
+                  class="menu-item mb-1 flex flex-wrap items-center gap-1 border p-1 rounded"
+                  :style="{ backgroundColor: screen.color, borderColor: screen.color, '--screen-text-color': screen.textColor || textColor }"
+                >
+                  <textarea v-model="item.text" rows="2" cols="30" class="menu-text mr-1 border rounded p-1 flex-1" placeholder="Menu text"></textarea>
+                  <input
+                    v-model="item.screen"
+                    :class="['menu-screen','mr-1','border','rounded','p-1','w-24', invalidMenuItemScreenIds.has(item.uid) ? 'invalid-field' : '']"
+                    placeholder="Screen id"
+                    :aria-invalid="invalidMenuItemScreenIds.has(item.uid) ? 'true' : null"
+                    :title="menuItemScreenTitle(item)"
+                  >
+                  <input v-model="item.command" class="menu-command mr-1 border rounded p-1 w-32" placeholder="Command">
+                  <button type="button" @click="moveMenuItemUp(sIdx, iIdx)" :disabled="iIdx===0" class="mr-1 action-btn" title="Move up">▲</button>
+                  <button type="button" @click="moveMenuItemDown(sIdx, iIdx)" :disabled="iIdx===screen.items.length-1" class="mr-1 action-btn" title="Move down">▼</button>
+                    <button type="button" @click="removeMenuItem(sIdx, iIdx)" class="action-btn" title="Remove item"><span class="w-4 h-4 flex items-center justify-center delete-icon">&times;</span></button>
+                </div>
+              </template>
+              <button type="button" @click="addMenuItem(screen)" class="mt-2 px-2 py-1 border rounded">Add Menu Item</button>
+            </div>
+          </div>
+        </template>
+        <button type="button" @click="addScreen()" class="mt-2 px-2 py-1 border rounded">Add Screen</button>
+      </div>
+    </fieldset>
+  </div>
+  <div v-show="activeTab==='boot'" class="space-y-4 tab-content">
+    <fieldset class="p-4 border rounded-lg shadow">
+      <legend class="flex items-center gap-1">Boot Sequence</legend>
+      <div v-for="(step, idx) in bootSequence" :key="step.uid" class="flex items-center flex-wrap gap-1 mb-1">
+        <textarea v-model="step.text" rows="2" cols="40" class="border rounded p-1 flex-1" placeholder="Boot text"></textarea>
+        <select v-model="step.type" class="border rounded p-1">
+          <option value="terminal">Terminal</option>
+          <option value="user">User</option>
+        </select>
+        <button type="button" @click="moveBootStepUp(bootSequence, idx)" :disabled="idx===0" class="action-btn">▲</button>
+        <button type="button" @click="moveBootStepDown(bootSequence, idx)" :disabled="idx===bootSequence.length-1" class="action-btn">▼</button>
+        <button type="button" @click="removeBootStep(bootSequence, idx)" class="action-btn"><span class="w-4 h-4 flex items-center justify-center delete-icon">&times;</span></button>
+      </div>
+      <button type="button" @click="addBootStep(bootSequence)" class="mt-2 px-2 py-1 border rounded">Add Entry</button>
+    </fieldset>
+    <fieldset class="p-4 border rounded-lg shadow">
+      <legend class="flex items-center gap-1">Locked Boot Sequence</legend>
+      <div v-for="(step, idx) in lockedBootSequence" :key="step.uid" class="flex items-center flex-wrap gap-1 mb-1">
+        <textarea v-model="step.text" rows="2" cols="40" class="border rounded p-1 flex-1" placeholder="Boot text"></textarea>
+        <select v-model="step.type" class="border rounded p-1">
+          <option value="terminal">Terminal</option>
+          <option value="user">User</option>
+        </select>
+        <button type="button" @click="moveBootStepUp(lockedBootSequence, idx)" :disabled="idx===0" class="action-btn">▲</button>
+        <button type="button" @click="moveBootStepDown(lockedBootSequence, idx)" :disabled="idx===lockedBootSequence.length-1" class="action-btn">▼</button>
+        <button type="button" @click="removeBootStep(lockedBootSequence, idx)" class="action-btn"><span class="w-4 h-4 flex items-center justify-center delete-icon">&times;</span></button>
+      </div>
+      <button type="button" @click="addBootStep(lockedBootSequence)" class="mt-2 px-2 py-1 border rounded">Add Entry</button>
+    </fieldset>
+  </div>
+  <div v-show="activeTab==='commands'" class="space-y-4 tab-content">
+    <fieldset class="p-4 border rounded-lg shadow">
+      <legend class="flex items-center gap-1">Commands</legend>
+      <div v-for="(cmd,idx) in commands" :key="cmd.uid" class="flex items-center flex-wrap gap-2 mb-2">
+        <input v-model="cmd.name" class="border rounded p-1 w-32" placeholder="Command">
+        <input
+          v-model="cmd.screen"
+          :class="['border','rounded','p-1','w-32', invalidCommandScreenIds.has(cmd.uid) ? 'invalid-field' : '']"
+          placeholder="Screen ID"
+          :aria-invalid="invalidCommandScreenIds.has(cmd.uid) ? 'true' : null"
+          :title="commandScreenTitle(cmd)"
+        >
+        <input v-model="cmd.command" class="border rounded p-1 w-32" placeholder="Response">
+        <label class="flex items-center gap-1"><input type="checkbox" v-model="cmd.help">Help</label>
+        <label class="flex items-center gap-1"><input type="checkbox" v-model="cmd.hacking">Hacking</label>
+        <div class="flex gap-1">
+          <button type="button" @click="moveCommandUp(idx)" :disabled="idx===0" class="action-btn" title="Move up">▲</button>
+          <button type="button" @click="moveCommandDown(idx)" :disabled="idx===commands.length-1" class="action-btn" title="Move down">▼</button>
+          <button type="button" @click="removeCommand(idx)" class="action-btn" title="Remove command"><span class="w-4 h-4 flex items-center justify-center delete-icon">&times;</span></button>
+        </div>
+      </div>
+      <button type="button" @click="addCommand" class="mt-2 action-btn">Add Command</button>
+    </fieldset>
+  </div>
+  <div v-show="activeTab==='hacking'" class="space-y-4 tab-content">
+    <fieldset class="p-4 border rounded-lg shadow" title="Configure hacking settings for locked terminals.">
+      <legend class="flex items-center gap-1">Hacking</legend>
+      <label class="block" title="If checked, the terminal starts locked and requires hacking before use."><input type="checkbox" id="locked" checked class="mr-1"> Locked</label>
+      <label id="difficulty-label" class="block" :title="difficultyTitle">Difficulty:
+        <select id="difficulty" v-model="difficultyChoice" class="border rounded p-1 ml-2" :title="difficultyTitle">
+          <option v-for="opt in difficultyOptions" :key="opt">{{ opt }}</option>
+        </select>
+      </label>
+      <label class="block" title="Starting number of attempts available to the user.">Attempts: <input type="number" id="attempts" min="1" value="4" class="ml-2 border rounded p-1 w-20"></label>
+      <label class="block" title="Maximum number of attempts allowed.">Max Attempts: <input type="number" id="max-attempts" min="1" value="4" class="ml-2 border rounded p-1 w-20"></label>
+      <label class="block" title="Password needed to unlock the terminal after hacking, e.g., HARDWARE.">Password: <input type="text" id="password" class="ml-2 border rounded p-1"></label>
+      <label class="block" title="Comma-separated words that will be removed as duds during hacking, e.g., RESEARCH, SCIENTIST.">Dud Words: <input type="text" id="dud-words" placeholder="WORD1, WORD2" class="ml-2 border rounded p-1"></label>
+      <label class="block" title="Header text shown at the top of the hacking screen.">Hacking Header: <input type="text" id="hacking-header-input" v-model="hackingHeader" class="ml-2 border rounded p-1"></label>
+      <label class="block">Hacking Text Color:
+        <input type="color" id="hack-text-color" class="ml-2" v-model="hackTextColor">
+        <input type="text" id="hack-text-color-hex" class="ml-2 border rounded p-1 w-24" v-model="hackTextColor">
+      </label>
+      <label class="block">Hacking Background Color:
+        <input type="color" id="hack-bg-color" class="ml-2" v-model="hackBgColor">
+        <input type="text" id="hack-bg-color-hex" class="ml-2 border rounded p-1 w-24" v-model="hackBgColor">
+      </label>
+      <label class="block">Hacking Border Color:
+        <input type="color" id="hack-border-color" class="ml-2" v-model="hackBorderColor">
+        <input type="text" id="hack-border-color-hex" class="ml-2 border rounded p-1 w-24" v-model="hackBorderColor">
+      </label>
+      <div id="dud-warning" class="text-red-600 hidden"></div>
+      <button type="button" @click="showDifficulties = !showDifficulties" class="mt-2 px-2 py-1 border rounded" title="Edit difficulty levels">Customize Difficulties</button>
+        <fieldset id="difficulties-fieldset" class="p-4 border rounded-lg shadow mt-4" title="Define hacking difficulty levels. Each level has a name, word count range, and password length range." v-show="showDifficulties">
+          <legend class="flex items-center gap-1">Difficulties</legend>
+          <div id="difficulties-container">
+            <div v-for="(d, idx) in difficulties" :key="d.uid" class="difficulty-item mb-2 p-2 border rounded bg-gray-50 dark:bg-gray-800">
+              <div class="flex items-center mb-2">
+                <button type="button" @click="d.open = !d.open" class="mr-2 action-btn">{{ d.open ? '▼' : '►' }}</button>
+                <input v-model="d.name" class="diff-name mr-2 border rounded p-1" placeholder="Name">
+                <button type="button" @click="removeDifficulty(idx)" class="action-btn" title="Remove difficulty"><span class="w-4 h-4 flex items-center justify-center delete-icon">&times;</span></button>
+              </div>
+              <div v-show="d.open" class="pl-6 space-y-1">
+                <label class="block">Words: <input type="number" v-model.number="d.wordCount[0]" class="word-min mr-1 border rounded p-1 w-16" min="1"> - <input type="number" v-model.number="d.wordCount[1]" class="word-max border rounded p-1 w-16" min="1"></label>
+                <label class="block">Length: <input type="number" v-model.number="d.length[0]" class="len-min mr-1 border rounded p-1 w-16" min="1"> - <input type="number" v-model.number="d.length[1]" class="len-max border rounded p-1 w-16" min="1"></label>
+              </div>
+            </div>
+            <button type="button" @click="addDifficulty()" class="mt-2 px-2 py-1 border rounded">Add Difficulty</button>
+          </div>
+        </fieldset>
+    </fieldset>
+  </div>
+  <div v-show="activeTab==='prefs'" class="space-y-4 tab-content">
+    <fieldset class="p-4 border rounded-lg shadow" title="Customize terminal appearance.">
+      <legend class="flex items-center gap-1">Default Appearance</legend>
+      <label class="block" title="Color of text displayed in the terminal, e.g., #7aff7a.">Default Text Color:
+        <input type="color" id="text-color" class="ml-2" v-model="textColor">
+        <input type="text" id="text-color-hex" class="ml-2 border rounded p-1 w-24" v-model="textColor">
+      </label>
+      <label class="block" title="Color of the terminal window outline, e.g., #008800.">Default Outline Color:
+        <input type="color" id="border-color" class="ml-2" v-model="borderColor">
+        <input type="text" id="border-color-hex" class="ml-2 border rounded p-1 w-24" v-model="borderColor">
+      </label>
+      <label class="block" title="Background color of the terminal window, e.g., #041204.">Default Background Color:
+        <input type="color" id="bg-color" class="ml-2" v-model="bgColor">
+        <input type="text" id="bg-color-hex" class="ml-2 border rounded p-1 w-24" v-model="bgColor">
+      </label>
+    </fieldset>
+    <fieldset class="p-4 border rounded-lg shadow" title="Configure audio options.">
+      <legend class="flex items-center gap-1">Audio</legend>
+      <label class="block" title="Directory scanned for additional enter key audio clips.">Custom Sound Directory:
+        <input type="text" class="ml-2 border rounded p-1 w-full max-w-xs" v-model="customSoundDir" placeholder="e.g. sounds/custom">
+      </label>
+    </fieldset>
+  </div>
+</form>
+</div>
+<script>
+const defaultDifficulties = [
+  { name: "Very Easy", wordCount: [8,10], length: [4,5] },
+  { name: "Easy", wordCount: [10,12], length: [6,7] },
+  { name: "Average", wordCount: [12,14], length: [8,9] },
+  { name: "Hard", wordCount: [15,17], length: [10,11] },
+  { name: "Very Hard", wordCount: [17,20], length: [12,15] }
+];
+const DEFAULT_TEXT_COLOR = '#7aff7a';
+const DEFAULT_BG_COLOR = '#041204';
+const DEFAULT_BORDER_COLOR = '#008800';
+const BASE_SCREEN_COLOR = '#0c2c5f';
+const DEFAULT_DOWNLOAD_BASENAME = 'config';
+const INVALID_FILENAME_CHARS = /[<>:"/\\|?*\x00-\x1F]/g;
+
+function sanitizeDownloadBaseName(name){
+  const trimmed=(name||'').trim();
+  if(!trimmed) return DEFAULT_DOWNLOAD_BASENAME;
+  const cleaned=trimmed.replace(INVALID_FILENAME_CHARS,'').replace(/\s+/g,' ');
+  const withoutLeadingDots=cleaned.replace(/^\.+/, '');
+  const withoutTrailingDotsOrSpaces=withoutLeadingDots.replace(/[. ]+$/, '');
+  return withoutTrailingDotsOrSpaces || DEFAULT_DOWNLOAD_BASENAME;
+}
+
+function buildDownloadFileName(name){
+  let base=sanitizeDownloadBaseName(name);
+  if(!base.toLowerCase().endsWith('.json')){
+    base=`${base}.json`;
+  }
+  return base;
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function hexToHsl(hex) {
+  let normalized = (hex || '').toString().trim();
+  if (normalized.startsWith('#')) {
+    normalized = normalized.slice(1);
+  }
+  if (normalized.length === 3) {
+    normalized = normalized.split('').map(ch => ch + ch).join('');
+  }
+  if (!/^[0-9a-f]{6}$/i.test(normalized)) {
+    return { h: 210, s: 60, l: 30 };
+  }
+  const r = parseInt(normalized.slice(0, 2), 16) / 255;
+  const g = parseInt(normalized.slice(2, 4), 16) / 255;
+  const b = parseInt(normalized.slice(4, 6), 16) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      default:
+        h = (r - g) / d + 4;
+        break;
+    }
+    h *= 60;
+  }
+
+  return { h, s: s * 100, l: l * 100 };
+}
+
+function hslToHex(h, s, l) {
+  h = ((h % 360) + 360) % 360;
+  s = clamp(s, 0, 100) / 100;
+  l = clamp(l, 0, 100) / 100;
+
+  const hue2rgb = (p, q, t) => {
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 1 / 2) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
+  };
+
+  let r;
+  let g;
+  let b;
+  if (s === 0) {
+    r = g = b = l;
+  } else {
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    const hk = h / 360;
+    r = hue2rgb(p, q, hk + 1 / 3);
+    g = hue2rgb(p, q, hk);
+    b = hue2rgb(p, q, hk - 1 / 3);
+  }
+
+  return '#' + [r, g, b].map(v => Math.round(v * 255).toString(16).padStart(2, '0')).join('');
+}
+
+// Generate screen accent colors by rotating hue and adjusting saturation/lightness.
+function generateScreenColor(baseHex, index) {
+  const base = hexToHsl(baseHex);
+  const hueStep = 37;
+  const lightCycle = [0, 6, -4, 12, -2, 8];
+  const satCycle = [0, -6, 5, -8, 7, -4];
+  const baseLightness = base.l + 28;
+  const baseSaturation = clamp(base.s, 45, 75);
+  const jitter = () => Math.random() * 4 - 2;
+  const hueJitter = () => Math.random() * 6 - 3;
+
+  const hue = (base.h + index * hueStep + hueJitter() + 360) % 360;
+  const lightness = clamp(baseLightness + lightCycle[index % lightCycle.length] + jitter(), 32, 82);
+  const saturation = clamp(baseSaturation + satCycle[index % satCycle.length] + jitter(), 38, 78);
+
+  const color = hslToHex(hue, saturation, lightness);
+  return /^#[0-9a-f]{6}$/i.test(color) ? color : baseHex;
+}
+
+const app = Vue.createApp({
+  data() {
+    return {
+        activeTab: 'content',
+        downloadName: DEFAULT_DOWNLOAD_BASENAME,
+        downloadUrl: '',
+        screens: [],
+        bootSequence:[{text:'',type:'terminal',uid:crypto.randomUUID?crypto.randomUUID():Math.random()}],
+        lockedBootSequence:[{text:'',type:'terminal',uid:crypto.randomUUID?crypto.randomUUID():Math.random()}],
+        commands: [
+          {name:'back',screen:'',command:'',help:false,hacking:false,action:'back',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
+          {name:'help',screen:'',command:'',help:true,hacking:false,action:'help',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
+          {name:'?',screen:'',command:'',help:true,hacking:false,action:'help',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
+          {name:'syntaxhelper',screen:'',command:'',help:false,hacking:true,action:'syntaxhelper',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
+          {name:'ADMIN OVERRIDE',screen:'',command:'Access granted.',help:false,hacking:true,action:'adminoverride',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
+          {name:'ADMIN ALLOWANCES',screen:'',command:'Allowances set to 99.',help:false,hacking:true,action:'adminallowances',uid:crypto.randomUUID?crypto.randomUUID():Math.random()}
+        ],
+        difficulties: [],
+        difficultyChoice: 'Average',
+        showDifficulties: false,
+        textColor: DEFAULT_TEXT_COLOR,
+        bgColor: DEFAULT_BG_COLOR,
+        borderColor: DEFAULT_BORDER_COLOR,
+        hackTextColor: DEFAULT_TEXT_COLOR,
+        hackBgColor: DEFAULT_BG_COLOR,
+        hackBorderColor: DEFAULT_BORDER_COLOR,
+        hackingHeader: '',
+        customSoundDir: '',
+        hasUnsavedChanges: false,
+        suppressUnsavedTracking: 0,
+        domUnsavedListeners: [],
+        beforeUnloadHandler: null,
+        collectionSnapshots: {
+          screens: '',
+          commands: '',
+          bootSequence: '',
+          lockedBootSequence: '',
+          difficulties: ''
+        }
+      };
+  },
+  computed: {
+    downloadFileName(){
+      return buildDownloadFileName(this.downloadName);
+    },
+    difficultyOptions() {
+      return ['Random', ...this.difficulties.map(d => d.name)];
+    },
+    difficultyTitle() {
+      return this.difficulties.map(d => `${d.name} (${d.length[0]}-${d.length[1]} letters, ${d.wordCount[0]}-${d.wordCount[1]} words)`).join('; ') + '; Random selects any difficulty.';
+    },
+    screenReferenceValidation() {
+      return findInvalidScreenReferences(this.screens, this.commands);
+    },
+    invalidMenuItemScreenIds() {
+      return this.screenReferenceValidation.invalidMenuItemIds;
+    },
+    invalidCommandScreenIds() {
+      return this.screenReferenceValidation.invalidCommandIds;
+    }
+  },
+  watch: {
+    textColor: {
+      handler() {
+        this.applyTheme();
+        this.markUnsaved();
+      },
+      flush: 'sync'
+    },
+    bgColor: {
+      handler() {
+        this.applyTheme();
+        this.markUnsaved();
+      },
+      flush: 'sync'
+    },
+    borderColor: {
+      handler() {
+        this.applyTheme();
+        this.markUnsaved();
+      },
+      flush: 'sync'
+    },
+    downloadName: {
+      handler() {
+        this.markUnsaved({ skipClear: true });
+      },
+      flush: 'sync'
+    },
+    screens: {
+      handler() {
+        const snapshot = this.serializeScreens();
+        const changed = snapshot !== this.collectionSnapshots.screens;
+        this.collectionSnapshots.screens = snapshot;
+        if(this.suppressUnsavedTracking || !changed) return;
+        this.markUnsaved();
+      },
+      deep: true,
+      flush: 'sync'
+    },
+    commands: {
+      handler() {
+        const snapshot = this.serializeCommands();
+        const changed = snapshot !== this.collectionSnapshots.commands;
+        this.collectionSnapshots.commands = snapshot;
+        if(this.suppressUnsavedTracking || !changed) return;
+        this.markUnsaved();
+      },
+      deep: true,
+      flush: 'sync'
+    },
+    bootSequence: {
+      handler() {
+        const snapshot = this.serializeBootSequence(this.bootSequence);
+        const changed = snapshot !== this.collectionSnapshots.bootSequence;
+        this.collectionSnapshots.bootSequence = snapshot;
+        if(this.suppressUnsavedTracking || !changed) return;
+        this.markUnsaved();
+      },
+      deep: true,
+      flush: 'sync'
+    },
+    lockedBootSequence: {
+      handler() {
+        const snapshot = this.serializeBootSequence(this.lockedBootSequence);
+        const changed = snapshot !== this.collectionSnapshots.lockedBootSequence;
+        this.collectionSnapshots.lockedBootSequence = snapshot;
+        if(this.suppressUnsavedTracking || !changed) return;
+        this.markUnsaved();
+      },
+      deep: true,
+      flush: 'sync'
+    },
+    difficulties: {
+      handler() {
+        const snapshot = this.serializeDifficulties();
+        const changed = snapshot !== this.collectionSnapshots.difficulties;
+        this.collectionSnapshots.difficulties = snapshot;
+        if(this.suppressUnsavedTracking || !changed) return;
+        this.markUnsaved();
+      },
+      deep: true,
+      flush: 'sync'
+    },
+    difficultyChoice: {
+      handler() {
+        this.markUnsaved();
+      },
+      flush: 'sync'
+    },
+    hackTextColor: {
+      handler() {
+        this.markUnsaved();
+      },
+      flush: 'sync'
+    },
+    hackBgColor: {
+      handler() {
+        this.markUnsaved();
+      },
+      flush: 'sync'
+    },
+    hackBorderColor: {
+      handler() {
+        this.markUnsaved();
+      },
+      flush: 'sync'
+    },
+    hackingHeader: {
+      handler() {
+        this.markUnsaved();
+      },
+      flush: 'sync'
+    },
+    customSoundDir: {
+      handler() {
+        this.markUnsaved();
+      },
+      flush: 'sync'
+    }
+  },
+  methods: {
+      runWithoutUnsavedTracking(fn){
+        this.suppressUnsavedTracking++;
+        try {
+          if (typeof fn === 'function') {
+            fn();
+          }
+        } finally {
+          Promise.resolve().then(() => {
+            this.suppressUnsavedTracking = Math.max(0, this.suppressUnsavedTracking - 1);
+          });
+        }
+      },
+      markUnsaved(options={}){
+        if(this.suppressUnsavedTracking) return;
+        const { skipClear = false } = options;
+        if(!skipClear){
+          this.clearDownloadUrl();
+        }
+        this.hideGenerationFeedback();
+        this.hasUnsavedChanges = true;
+      },
+      resetUnsavedChanges(){
+        this.refreshCollectionSnapshots();
+        this.hasUnsavedChanges = false;
+      },
+      clearDownloadUrl(){
+        if(this.downloadUrl){
+          URL.revokeObjectURL(this.downloadUrl);
+          this.downloadUrl='';
+        }
+      },
+      setDownloadPanelVisible(visible){
+        const panel=document.getElementById('download-panel');
+        if(panel){
+          panel.classList.toggle('hidden', !visible);
+        }
+      },
+      hideGenerationFeedback(){
+        const feedback = document.getElementById('generate-feedback');
+        if(feedback){
+          feedback.classList.add('hidden');
+        }
+        this.setDownloadPanelVisible(!!this.downloadUrl);
+      },
+      serializeBootSequence(seq){
+        return JSON.stringify(seq.map(step=>({
+          text: step.text,
+          type: step.type
+        })));
+      },
+      serializeScreens(){
+        return JSON.stringify(this.screens.map(scr=>({
+          id: scr.id,
+          textColor: scr.textColor,
+          bgColor: scr.bgColor,
+          borderColor: scr.borderColor,
+          items: scr.items.map(it=>({
+            text: it.text,
+            screen: it.screen,
+            command: it.command
+          }))
+        })));
+      },
+      serializeCommands(){
+        return JSON.stringify(this.commands.map(cmd=>({
+          name: cmd.name,
+          screen: cmd.screen,
+          command: cmd.command,
+          help: !!cmd.help,
+          hacking: !!cmd.hacking,
+          action: cmd.action
+        })));
+      },
+      serializeDifficulties(){
+        return JSON.stringify(this.difficulties.map(diff=>({
+          name: diff.name,
+          wordCount: Array.isArray(diff.wordCount) ? [...diff.wordCount] : diff.wordCount,
+          length: Array.isArray(diff.length) ? [...diff.length] : diff.length
+        })));
+      },
+      refreshCollectionSnapshots(){
+        this.collectionSnapshots.screens = this.serializeScreens();
+        this.collectionSnapshots.commands = this.serializeCommands();
+        this.collectionSnapshots.bootSequence = this.serializeBootSequence(this.bootSequence);
+        this.collectionSnapshots.lockedBootSequence = this.serializeBootSequence(this.lockedBootSequence);
+        this.collectionSnapshots.difficulties = this.serializeDifficulties();
+      },
+      updateDownloadNameFromFile(fileName=''){
+        this.runWithoutUnsavedTracking(()=>{
+          const base=(fileName||'').replace(/\.json$/i,'');
+          this.downloadName=sanitizeDownloadBaseName(base);
+        });
+      },
+      applyTheme() {
+        const root = document.documentElement;
+        root.style.setProperty('--text-color', this.textColor || DEFAULT_TEXT_COLOR);
+        root.style.setProperty('--terminal-bg', this.bgColor || DEFAULT_BG_COLOR);
+        root.style.setProperty('--border-color', this.borderColor || DEFAULT_BORDER_COLOR);
+      },
+      addScreen(id='') {
+        const text = this.textColor || DEFAULT_TEXT_COLOR;
+        const bg = this.bgColor || DEFAULT_BG_COLOR;
+        const border = this.borderColor || DEFAULT_BORDER_COLOR;
+        const index = this.screens.length;
+        const color = generateScreenColor(BASE_SCREEN_COLOR, index);
+        this.screens.push({
+          id,
+          color,
+          items:[{text:'', screen:'', command:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()}],
+          open:true,
+          uid:crypto.randomUUID?crypto.randomUUID():Math.random(),
+          textColor:text,
+          bgColor:bg,
+          borderColor:border
+        });
+        this.$nextTick(this.initSortables);
+      },
+      removeScreen(idx) {
+        this.screens.splice(idx,1);
+        this.$nextTick(this.initSortables);
+      },
+      addCommand() {
+        this.commands.push({name:'',screen:'',command:'',help:false,hacking:false,action:'',uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+      },
+      removeCommand(idx) {
+        this.commands.splice(idx,1);
+      },
+      moveCommandUp(idx) {
+        if (idx <= 0) return;
+        const arr = this.commands;
+        [arr[idx - 1], arr[idx]] = [arr[idx], arr[idx - 1]];
+      },
+      moveCommandDown(idx) {
+        if (idx >= this.commands.length - 1) return;
+        const arr = this.commands;
+        [arr[idx], arr[idx + 1]] = [arr[idx + 1], arr[idx]];
+      },
+      addMenuItem(screen) {
+        screen.items.push({text:'', screen:'', command:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+        this.$nextTick(this.initSortables);
+      },
+        removeMenuItem(sIdx, iIdx) {
+          this.screens[sIdx].items.splice(iIdx,1);
+          this.$nextTick(this.initSortables);
+        },
+        moveScreenUp(idx) {
+          if (idx <= 0) return;
+          const arr = this.screens;
+          [arr[idx - 1], arr[idx]] = [arr[idx], arr[idx - 1]];
+          this.$nextTick(this.initSortables);
+        },
+        moveScreenDown(idx) {
+          if (idx >= this.screens.length - 1) return;
+          const arr = this.screens;
+          [arr[idx], arr[idx + 1]] = [arr[idx + 1], arr[idx]];
+          this.$nextTick(this.initSortables);
+        },
+        moveMenuItemUp(sIdx, iIdx) {
+          if (iIdx <= 0) return;
+          const items = this.screens[sIdx].items;
+          [items[iIdx - 1], items[iIdx]] = [items[iIdx], items[iIdx - 1]];
+          this.$nextTick(this.initSortables);
+        },
+        moveMenuItemDown(sIdx, iIdx) {
+          const items = this.screens[sIdx].items;
+          if (iIdx >= items.length - 1) return;
+          [items[iIdx], items[iIdx + 1]] = [items[iIdx + 1], items[iIdx]];
+          this.$nextTick(this.initSortables);
+        },
+        menuItemScreenTitle(item) {
+          if (!this.invalidMenuItemScreenIds.has(item.uid)) return 'Screen id';
+          const screen = (item.screen || '').trim();
+          return screen ? `Unknown screen "${screen}"` : 'Screen id';
+        },
+        commandScreenTitle(cmd) {
+          if (!this.invalidCommandScreenIds.has(cmd.uid)) return 'Screen ID';
+          const screen = (cmd.screen || '').trim();
+          return screen ? `Unknown screen "${screen}"` : 'Screen ID';
+        },
+        addBootStep(seq) {
+        seq.push({text:'', type:'terminal', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+        this.$nextTick(this.initSortables);
+        },
+        removeBootStep(seq, idx) {
+        seq.splice(idx,1);
+        this.$nextTick(this.initSortables);
+        },
+        moveBootStepUp(seq, idx) {
+        if(idx<=0) return;
+        [seq[idx-1], seq[idx]] = [seq[idx], seq[idx-1]];
+        this.$nextTick(this.initSortables);
+        },
+      moveBootStepDown(seq, idx) {
+        if(idx>=seq.length-1) return;
+        [seq[idx], seq[idx+1]] = [seq[idx+1], seq[idx]];
+        this.$nextTick(this.initSortables);
+      },
+        initSortables() {
+        },
+      addDifficulty(d={name:'', wordCount:[1,1], length:[1,1]}) {
+        this.difficulties.push({...d, open:false, uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+        this.$nextTick(this.initSortables);
+      },
+      removeDifficulty(idx) {
+        this.difficulties.splice(idx,1);
+        this.$nextTick(this.initSortables);
+      },
+      loadConfig(config) {
+        this.runWithoutUnsavedTracking(()=>{
+          this.clearDownloadUrl();
+          this.hideGenerationFeedback();
+          document.getElementById('titles').value = (config.titleLines || []).join('\n');
+          document.getElementById('headers').value = (config.headerLines || []).join('\n');
+          this.bootSequence = (config.bootSequence || []).map(s=>({...s, uid:crypto.randomUUID?crypto.randomUUID():Math.random()}));
+          this.lockedBootSequence = (config.lockedBootSequence || []).map(s=>({...s, uid:crypto.randomUUID?crypto.randomUUID():Math.random()}));
+          if(!this.bootSequence.length) this.bootSequence.push({text:'',type:'terminal',uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+          if(!this.lockedBootSequence.length) this.lockedBootSequence.push({text:'',type:'terminal',uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+          this.screens = [];
+          this.commands = [];
+          const style = config.style || {};
+          const globalText = style.textColor || DEFAULT_TEXT_COLOR;
+          const globalBg = style.backgroundColor || DEFAULT_BG_COLOR;
+          const globalBorder = style.borderColor || DEFAULT_BORDER_COLOR;
+          this.textColor = globalText;
+          this.bgColor = globalBg;
+          this.borderColor = globalBorder;
+          const hackingStyle = config.hackingStyle || {};
+          this.hackTextColor = hackingStyle.textColor || globalText;
+          this.hackBgColor = hackingStyle.backgroundColor || globalBg;
+          this.hackBorderColor = hackingStyle.borderColor || globalBorder;
+          this.hackingHeader = (config.hacking && config.hacking.header) || '';
+          this.customSoundDir = typeof config.customSoundDir === 'string' ? config.customSoundDir : '';
+          Object.entries(config.screens || {}).forEach(([id, data]) => {
+            const color = generateScreenColor(BASE_SCREEN_COLOR, this.screens.length);
+            const screen = {id, color, items:[], open:true, uid:crypto.randomUUID?crypto.randomUUID():Math.random(), textColor:globalText, bgColor:globalBg, borderColor:globalBorder};
+            const items = Array.isArray(data) ? data : (data.items || []);
+            if(!Array.isArray(data) && data.style){
+              if(data.style.textColor) screen.textColor = data.style.textColor;
+              if(data.style.backgroundColor) screen.bgColor = data.style.backgroundColor;
+              if(data.style.borderColor) screen.borderColor = data.style.borderColor;
+            }
+            items.forEach(item=>{
+              if (typeof item === 'string') {
+                screen.items.push({text:item, screen:'', command:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+              } else {
+                screen.items.push({
+                  text: item.text || '',
+                  screen: item.screen || '',
+                  command: item.command || '',
+                  uid: crypto.randomUUID?crypto.randomUUID():Math.random()
+                });
+              }
+            });
+            if(!screen.items.length) screen.items.push({text:'', screen:'', command:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+            this.screens.push(screen);
+          });
+          Object.entries(config.commands || {}).forEach(([name, info])=>{
+            this.commands.push({
+              name,
+              screen: info.screen || '',
+              command: info.command || '',
+              help: !!info.help,
+              hacking: !!info.hacking,
+              action: info.action || '',
+              uid: crypto.randomUUID?crypto.randomUUID():Math.random()
+            });
+          });
+          document.getElementById('locked').checked = config.locked || false;
+          const diffs = config.hacking?.difficulties || defaultDifficulties;
+          this.difficulties = [];
+          diffs.forEach(d=>this.addDifficulty(d));
+          this.difficultyChoice = config.hacking?.difficulty ?? 'Random';
+          attemptsEl.value = config.hacking?.attempts ?? 4;
+          maxAttemptsEl.value = config.hacking?.maxAttempts ?? 4;
+          passwordEl.value = config.hacking?.password || '';
+          dudWordsEl.value = (config.hacking?.dudWords || []).join(', ');
+          this.$nextTick(this.initSortables);
+        });
+        this.resetUnsavedChanges();
+      },
+      buildMissingTargetMessage(missingTargets) {
+        const details = [];
+        missingTargets.forEach((info, target) => {
+          const parts = [];
+          if(info.menuItems){
+            parts.push(`${info.menuItems} menu item${info.menuItems === 1 ? '' : 's'}`);
+          }
+          if(info.commands){
+            parts.push(`${info.commands} command${info.commands === 1 ? '' : 's'}`);
+          }
+          details.push(`"${target}" (${parts.join(' and ')})`);
+        });
+        if(!details.length) return '';
+        const suffix = details.length === 1 ? '' : 's';
+        return `Unknown screen reference${suffix}: ${details.join(', ')}.`;
+      },
+      showGenerationError(message) {
+        const feedback = document.getElementById('generate-feedback');
+        feedback.textContent = message || 'Resolve highlighted screen references before generating.';
+        feedback.classList.remove('hidden');
+        feedback.classList.remove('text-green-600');
+        feedback.classList.add('text-red-600');
+        this.clearDownloadUrl();
+        this.setDownloadPanelVisible(true);
+      },
+      showGenerationSuccess(message) {
+        const feedback = document.getElementById('generate-feedback');
+        feedback.textContent = message;
+        feedback.classList.remove('hidden');
+        feedback.classList.remove('text-red-600');
+        feedback.classList.add('text-green-600');
+        this.setDownloadPanelVisible(true);
+      },
+      handleDownloadClick(){
+        if(!this.downloadUrl) return;
+        this.resetUnsavedChanges();
+      },
+      confirmNavigation(message){
+        if(!this.hasUnsavedChanges) return true;
+        const prompt = message || 'You have unsaved changes. Continue without exporting your configuration?';
+        const confirmed = window.confirm(prompt);
+        if(confirmed){
+          this.hasUnsavedChanges = false;
+        }
+        return confirmed;
+      },
+      handleBackToTerminal(event){
+        if(event && (event.metaKey || event.ctrlKey || event.shiftKey || event.button === 1)){
+          return;
+        }
+        if(event) event.preventDefault();
+        if(!this.confirmNavigation()) return;
+        const href = event?.currentTarget?.getAttribute('href') || 'index.html';
+        const go=()=>{ window.location.href = href; };
+        if(typeof playSound === 'function'){
+          const audio=playSound('Pip/select3.wav');
+          if(audio && typeof audio.addEventListener === 'function'){
+            audio.addEventListener('ended', go, {once:true});
+            setTimeout(go,150);
+            return;
+          }
+        }
+        go();
+      },
+      handleBeforeUnload(event){
+        if(this.hasUnsavedChanges){
+          event.preventDefault();
+          event.returnValue='';
+        }
+      },
+      setupUnsavedTracking(){
+        const tracked=[
+          {id:'titles', event:'input'},
+          {id:'headers', event:'input'},
+          {id:'attempts', event:'input'},
+          {id:'max-attempts', event:'input'},
+          {id:'password', event:'input'},
+          {id:'dud-words', event:'input'},
+          {id:'locked', event:'change'}
+        ];
+        tracked.forEach(({id,event})=>{
+          const el=document.getElementById(id);
+          if(!el) return;
+          const handler=()=>this.markUnsaved();
+          el.addEventListener(event,handler);
+          this.domUnsavedListeners.push({el,event,handler});
+        });
+        this.beforeUnloadHandler=(e)=>this.handleBeforeUnload(e);
+        window.addEventListener('beforeunload', this.beforeUnloadHandler);
+      },
+      handleSubmit() {
+      if (!validateDudWords()) {
+        dudWordsEl.reportValidity();
+        return;
+      }
+      const validation = this.screenReferenceValidation;
+      if (validation.missingTargets.size) {
+        const message = this.buildMissingTargetMessage(validation.missingTargets);
+        this.showGenerationError(message);
+        return;
+      }
+      const rawTitles = document.getElementById('titles').value.split('\n');
+      const titles = rawTitles.length === 1 && rawTitles[0] === '' ? [] : rawTitles;
+      const rawHeaders = document.getElementById('headers').value.split('\n');
+      const headers = rawHeaders.length === 1 && rawHeaders[0] === '' ? [] : rawHeaders;
+      const bootSeq = this.bootSequence.filter(s=>s.text.trim()).map(s=>({text:s.text, type:s.type}));
+      const lockedBootSeq = this.lockedBootSequence.filter(s=>s.text.trim()).map(s=>({text:s.text, type:s.type}));
+      const textColor = this.textColor || DEFAULT_TEXT_COLOR;
+      const backgroundColor = this.bgColor || DEFAULT_BG_COLOR;
+      const borderColor = this.borderColor || DEFAULT_BORDER_COLOR;
+      const hackTextColor = this.hackTextColor || textColor;
+      const hackBgColor = this.hackBgColor || backgroundColor;
+      const hackBorderColor = this.hackBorderColor || borderColor;
+      const screensObj = {};
+      this.screens.forEach(scr=>{
+        const id = scr.id.trim();
+        if(!id) return;
+        const items=[];
+        scr.items.forEach(it=>{
+          const text=(it.text||'').trimEnd();
+          const screen=(it.screen||'').trim();
+          const command=(it.command||'').trim();
+          if(!text && !screen && !command) return;
+          if(screen && command){ items.push({text,screen,command}); }
+          else if(screen){ items.push({text,screen}); }
+          else if(command){ items.push({text,command}); }
+          else { items.push(text); }
+        });
+        const style = {};
+        if(scr.textColor !== textColor) style.textColor = scr.textColor;
+        if(scr.bgColor !== backgroundColor) style.backgroundColor = scr.bgColor;
+        if(scr.borderColor !== borderColor) style.borderColor = scr.borderColor;
+        screensObj[id] = Object.keys(style).length ? {items, style} : items;
+      });
+      const commandsObj = {};
+      this.commands.forEach(c=>{
+        const name=(c.name||'').trim();
+        if(!name) return;
+        const screen=(c.screen||'').trim();
+        const message=(c.command||'').trim();
+        const action=(c.action||'').trim();
+        const obj={};
+        if(screen) obj.screen=screen;
+        if(message) obj.command=message;
+        if(action) obj.action=action;
+        if(c.help) obj.help=true;
+        if(c.hacking) obj.hacking=true;
+        if(Object.keys(obj).length) commandsObj[name]=obj;
+      });
+      const diffValue = this.difficultyChoice;
+      const difficulty = diffValue === 'Random' ? undefined : diffValue;
+      const password = passwordEl.value.trim();
+      const dudWords = dudWordsEl.value.split(',').map(s=>s.trim()).filter(Boolean);
+      const attempts = parseInt(attemptsEl.value,10);
+      const maxAttempts = parseInt(maxAttemptsEl.value,10);
+      const locked = document.getElementById('locked').checked;
+      const style = { textColor, backgroundColor, borderColor };
+      const hackingStyle = {
+        textColor: hackTextColor,
+        backgroundColor: hackBgColor,
+        borderColor: hackBorderColor
+      };
+      const hacking = { difficulties: this.difficulties.map(({name, wordCount, length})=>({name, wordCount, length})) };
+      if (difficulty) hacking.difficulty = difficulty;
+      if (!isNaN(attempts) && attempts !== 4) hacking.attempts = attempts;
+      if (!isNaN(maxAttempts) && maxAttempts !== 4) hacking.maxAttempts = maxAttempts;
+      if (password) hacking.password = password;
+      if (dudWords.length) hacking.dudWords = dudWords;
+      if (this.hackingHeader) hacking.header = this.hackingHeader;
+      const customSoundDir = (this.customSoundDir || '').trim();
+      this.runWithoutUnsavedTracking(()=>{
+        this.downloadName = sanitizeDownloadBaseName(this.downloadName);
+      });
+      const config = {
+        titleLines: titles,
+        headerLines: headers,
+        bootSequence: bootSeq,
+        lockedBootSequence: lockedBootSeq,
+        screens: screensObj,
+        style,
+        hackingStyle,
+        locked,
+        customSoundDir,
+        hacking
+      };
+      if(Object.keys(commandsObj).length) config.commands = commandsObj;
+      const blob = new Blob([JSON.stringify(config, null, 2)], {type: 'application/json'});
+      const url = URL.createObjectURL(blob);
+      const fileName = this.downloadFileName;
+      this.clearDownloadUrl();
+      this.downloadUrl = url;
+      this.showGenerationSuccess(`Generated ${fileName} at ${new Date().toLocaleTimeString()}`);
+    }
+  },
+  mounted() {
+    this.runWithoutUnsavedTracking(()=>{
+      this.addScreen('menu');
+      defaultDifficulties.forEach(d=>this.addDifficulty(d));
+    });
+    this.$nextTick(this.initSortables);
+    this.applyTheme();
+    this.setupUnsavedTracking();
+    this.resetUnsavedChanges();
+  },
+  beforeUnmount(){
+    if(this.downloadUrl){
+      URL.revokeObjectURL(this.downloadUrl);
+      this.downloadUrl='';
+    }
+    if(this.beforeUnloadHandler){
+      window.removeEventListener('beforeunload', this.beforeUnloadHandler);
+      this.beforeUnloadHandler=null;
+    }
+    if(Array.isArray(this.domUnsavedListeners)){
+      this.domUnsavedListeners.forEach(({el,event,handler})=>{
+        if(el && handler) el.removeEventListener(event,handler);
+      });
+      this.domUnsavedListeners=[];
+    }
+  }
+});
+
+const vm = app.mount('#builder-form');
+
+document.getElementById('builder-form').addEventListener('submit', e => {
+  e.preventDefault();
+  vm.handleSubmit();
+});
+document.getElementById('load-config').addEventListener('click', () => document.getElementById('config-file').click());
+document.getElementById('config-file').addEventListener('change', e => {
+  const file = e.target.files[0];
+  if (!file) return;
+  if (vm.hasUnsavedChanges && !vm.confirmNavigation('You have unsaved changes that will be replaced by the loaded configuration. Continue?')) {
+    e.target.value = '';
+    return;
+  }
+  const reader = new FileReader();
+    reader.onload = () => {
+      const config = JSON.parse(reader.result);
+      vm.loadConfig(config);
+      vm.updateDownloadNameFromFile(file.name);
+    };
+  reader.readAsText(file);
+  e.target.value = '';
+});
+
+function playSound(src){
+  const a=new Audio(src);
+  a.play();
+  return a;
+}
+
+const wrapper=document.getElementById('builder-wrapper');
+wrapper.classList.add('boot-load');
+wrapper.addEventListener('animationend',e=>{
+  if(e.animationName==='boot-reveal') wrapper.classList.remove('boot-load');
+});
+setTimeout(()=>wrapper.classList.remove('boot-load'),2000);
+playSound('Pip/Boot/Boot1.wav');
+
+const burstSounds=Array.from({length:17},(_,i)=>`Pip/Burst Static/BurstStatic${String(i+1).padStart(2,'0')}.wav`);
+function playBurst(){ playSound(burstSounds[Math.floor(Math.random()*burstSounds.length)]); }
+function triggerTabEffect(){
+  playBurst();
+  wrapper.classList.add('shake');
+  setTimeout(()=>wrapper.classList.remove('shake'),350);
+}
+
+const tabsBar=document.getElementById('tabs-bar');
+const tabButtons=[...tabsBar.querySelectorAll('button')];
+let currentTabIndex=0;
+tabButtons.forEach((btn,i)=>{
+  btn.addEventListener('click',()=>{
+    if(i<currentTabIndex) playSound('Pip/RotaryVertical01.wav');
+    else if(i>currentTabIndex) playSound('Pip/RotaryVertical03.wav');
+    currentTabIndex=i;
+    triggerTabEffect();
+  });
+});
+
+const HOVER_SOUND_SELECTOR='button, a[href], input, textarea, select, [role="button"], [tabindex]:not([tabindex="-1"])';
+function findHoverSoundTarget(element){
+  if(!(element instanceof Element)) return null;
+  const candidate=element.closest(HOVER_SOUND_SELECTOR);
+  if(!candidate) return null;
+  if(!candidate.closest('#builder-wrapper')) return null;
+  if(candidate.matches(':disabled')) return null;
+  if(candidate.getAttribute('aria-disabled')==='true') return null;
+  return candidate;
+}
+
+document.addEventListener('mouseover',e=>{
+  const hoverTarget=findHoverSoundTarget(e.target);
+  if(!hoverTarget) return;
+  if(hoverTarget.dataset.hoverSoundPlayed) return;
+  playSound('Pip/Highlight4.wav');
+  hoverTarget.dataset.hoverSoundPlayed='1';
+  const resetHoverSound=()=>{
+    delete hoverTarget.dataset.hoverSoundPlayed;
+  };
+  hoverTarget.addEventListener('mouseleave',resetHoverSound,{once:true});
+  hoverTarget.addEventListener('blur',resetHoverSound,{once:true});
+});
+document.addEventListener('focusin',e=>{
+  const focusTarget=findHoverSoundTarget(e.target);
+  if(!focusTarget) return;
+  if(focusTarget.dataset.hoverSoundPlayed) return;
+  playSound('Pip/Highlight4.wav');
+});
+
+const darkToggle=document.getElementById('dark-toggle');
+let darkToggleCount=0;
+darkToggle.addEventListener('click',()=>{
+  const isDark=document.documentElement.classList.toggle('dark');
+  if(isDark){
+    if(darkToggleCount>0) playSound('Pip/LightOff.wav');
+  }else{
+    playSound('Pip/LightOn.wav');
+  }
+  darkToggleCount++;
+});
+
+document.addEventListener('click',e=>{
+  const btn=e.target.closest('button, a.top-line-btn');
+  if(!btn) return;
+  if(btn.id==='dark-toggle' || btn.classList.contains('tab-btn') || btn.id==='back-to-terminal') return;
+  playSound('Pip/select3.wav');
+});
+
+// Preload select sound to reduce latency
+const backSelectPreload=new Audio('Pip/select3.wav');
+backSelectPreload.preload='auto';
+backSelectPreload.load();
+
+const passwordEl = document.getElementById('password');
+const dudWordsEl = document.getElementById('dud-words');
+const dudWarningEl = document.getElementById('dud-warning');
+const attemptsEl = document.getElementById('attempts');
+const maxAttemptsEl = document.getElementById('max-attempts');
+
+function validateDudWords() {
+  const password = passwordEl.value.trim();
+  const duds = dudWordsEl.value.split(',').map(s => s.trim()).filter(Boolean);
+  let msg = '';
+  if (duds.length > 0) {
+    if (password) {
+      const len = password.length;
+      if (duds.some(w => w.length !== len)) {
+        msg = 'Dud words must match the password length.';
+      }
+    } else {
+      const len = duds[0].length;
+      if (duds.some(w => w.length !== len)) {
+        msg = 'All dud words must be the same length.';
+      }
+    }
+  }
+  dudWordsEl.setCustomValidity(msg);
+  dudWarningEl.textContent = msg;
+  dudWarningEl.classList.toggle('hidden', !msg);
+  return !msg;
+}
+
+passwordEl.addEventListener('input', validateDudWords);
+dudWordsEl.addEventListener('input', validateDudWords);
+</script>
+</body>
+</html>

--- a/builder.html
+++ b/builder.html
@@ -78,6 +78,39 @@
     .menu-item {
       color: inherit;
     }
+    .sound-toggle-btn {
+      width: 2rem;
+      height: 2rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .sound-popover {
+      position: absolute;
+      right: 0;
+      top: 100%;
+      margin-top: 0.25rem;
+      padding: 0.5rem;
+      border: 2px solid #d1d5db;
+      border-radius: 0.5rem;
+      background-color: #ffffff;
+      box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+      min-width: 12rem;
+      z-index: 20;
+    }
+    .dark .sound-popover {
+      background-color: var(--terminal-bg);
+      border-color: var(--border-color);
+      box-shadow: 0 4px 12px rgba(0,255,0,0.15);
+    }
+    .sound-popover label {
+      font-size: 0.75rem;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+    .sound-popover input {
+      width: 100%;
+    }
     .dark .screen,
     .dark .menu-item {
       color: var(--screen-text-color, var(--text-color));
@@ -302,6 +335,7 @@
       <button type="button" @click="activeTab='boot'" :class="['tab-btn', activeTab==='boot' ? 'tab-btn-active' : '']">Boot</button>
       <button type="button" @click="activeTab='commands'" :class="['tab-btn', activeTab==='commands' ? 'tab-btn-active' : '']">Commands</button>
       <button type="button" @click="activeTab='hacking'" :class="['tab-btn', activeTab==='hacking' ? 'tab-btn-active' : '']">Hacking</button>
+      <button type="button" @click="activeTab='sounds'" :class="['tab-btn', activeTab==='sounds' ? 'tab-btn-active' : '']">Sounds</button>
       <button type="button" @click="activeTab='prefs'" :class="['tab-btn', activeTab==='prefs' ? 'tab-btn-active' : '']">Preferences</button>
     </div>
   <div v-show="activeTab==='content'" class="space-y-4 tab-content">
@@ -351,7 +385,7 @@
               <template v-for="(item, iIdx) in screen.items">
                 <div
                   :key="item.uid"
-                  class="menu-item mb-1 flex flex-wrap items-center gap-1 border p-1 rounded"
+                  class="menu-item relative mb-1 flex flex-wrap items-center gap-1 border p-1 rounded"
                   :style="{ backgroundColor: screen.color, borderColor: screen.color, '--screen-text-color': screen.textColor || textColor }"
                 >
                   <textarea v-model="item.text" rows="2" cols="30" class="menu-text mr-1 border rounded p-1 flex-1" placeholder="Menu text"></textarea>
@@ -363,6 +397,27 @@
                     :title="menuItemScreenTitle(item)"
                   >
                   <input v-model="item.command" class="menu-command mr-1 border rounded p-1 w-32" placeholder="Command">
+                  <button
+                    type="button"
+                    class="action-btn sound-toggle-btn"
+                    title="Configure sound effect"
+                    @click.stop="toggleSoundEditor(item)"
+                    :aria-expanded="item.showSoundEditor ? 'true' : 'false'"
+                  >
+                    🔊
+                  </button>
+                  <div v-if="item.showSoundEditor" class="sound-popover" @click.stop>
+                    <label class="block mb-1">Sound Path</label>
+                    <input
+                      v-model="item.sound"
+                      class="border rounded p-1"
+                      placeholder="Optional sound"
+                      aria-label="Sound path"
+                      title="Optional sound file path. Relative paths use the Custom Sound Directory when provided."
+                      @keydown.esc.stop.prevent="item.showSoundEditor = false"
+                    >
+                    <button type="button" class="mt-2 action-btn w-full" @click="item.showSoundEditor = false">Close</button>
+                  </div>
                   <button type="button" @click="moveMenuItemUp(sIdx, iIdx)" :disabled="iIdx===0" class="mr-1 action-btn" title="Move up">▲</button>
                   <button type="button" @click="moveMenuItemDown(sIdx, iIdx)" :disabled="iIdx===screen.items.length-1" class="mr-1 action-btn" title="Move down">▼</button>
                     <button type="button" @click="removeMenuItem(sIdx, iIdx)" class="action-btn" title="Remove item"><span class="w-4 h-4 flex items-center justify-center delete-icon">&times;</span></button>
@@ -409,7 +464,7 @@
   <div v-show="activeTab==='commands'" class="space-y-4 tab-content">
     <fieldset class="p-4 border rounded-lg shadow">
       <legend class="flex items-center gap-1">Commands</legend>
-      <div v-for="(cmd,idx) in commands" :key="cmd.uid" class="flex items-center flex-wrap gap-2 mb-2">
+      <div v-for="(cmd,idx) in commands" :key="cmd.uid" class="relative flex items-center flex-wrap gap-2 mb-2">
         <input v-model="cmd.name" class="border rounded p-1 w-32" placeholder="Command">
         <input
           v-model="cmd.screen"
@@ -419,6 +474,27 @@
           :title="commandScreenTitle(cmd)"
         >
         <input v-model="cmd.command" class="border rounded p-1 w-32" placeholder="Response">
+        <button
+          type="button"
+          class="action-btn sound-toggle-btn"
+          title="Configure sound effect"
+          @click.stop="toggleSoundEditor(cmd)"
+          :aria-expanded="cmd.showSoundEditor ? 'true' : 'false'"
+        >
+          🔊
+        </button>
+        <div v-if="cmd.showSoundEditor" class="sound-popover" @click.stop>
+          <label class="block mb-1">Sound Path</label>
+          <input
+            v-model="cmd.sound"
+            class="border rounded p-1"
+            placeholder="Optional sound"
+            aria-label="Sound path"
+            title="Optional sound file path. Relative paths use the Custom Sound Directory when provided."
+            @keydown.esc.stop.prevent="cmd.showSoundEditor = false"
+          >
+          <button type="button" class="mt-2 action-btn w-full" @click="cmd.showSoundEditor = false">Close</button>
+        </div>
         <label class="flex items-center gap-1"><input type="checkbox" v-model="cmd.help">Help</label>
         <label class="flex items-center gap-1"><input type="checkbox" v-model="cmd.hacking">Hacking</label>
         <div class="flex gap-1">
@@ -477,6 +553,33 @@
         </fieldset>
     </fieldset>
   </div>
+  <div v-show="activeTab==='sounds'" class="space-y-4 tab-content">
+    <fieldset class="p-4 border rounded-lg shadow" title="Configure how the terminal locates custom audio files.">
+      <legend class="flex items-center gap-1">Sound Directory</legend>
+      <label class="block" title="Directory scanned for additional audio clips. Relative sound paths are resolved against this directory.">
+        Custom Sound Directory:
+        <input type="text" class="ml-2 border rounded p-1 w-full max-w-xs" v-model="customSoundDir" placeholder="e.g. sounds/custom">
+      </label>
+    </fieldset>
+    <fieldset class="p-4 border rounded-lg shadow" title="Provide custom sound effects for terminal interactions.">
+      <legend class="flex items-center gap-1">Sound Overrides</legend>
+      <p class="text-sm text-gray-600 dark:text-gray-300 mb-3">Leave a field blank to use the built-in audio. Relative paths use the Custom Sound Directory when provided.</p>
+      <div class="grid gap-4 md:grid-cols-2">
+        <div v-for="field in soundFieldDefs" :key="field.key">
+          <label class="block text-sm font-semibold" :title="field.description">
+            {{ field.label }}
+            <input
+              type="text"
+              class="mt-1 border rounded p-1 w-full"
+              v-model="soundSettings[field.key]"
+              :placeholder="field.placeholder || 'Optional sound path'"
+            >
+          </label>
+          <p v-if="field.description" class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ field.description }}</p>
+        </div>
+      </div>
+    </fieldset>
+  </div>
   <div v-show="activeTab==='prefs'" class="space-y-4 tab-content">
     <fieldset class="p-4 border rounded-lg shadow" title="Customize terminal appearance.">
       <legend class="flex items-center gap-1">Default Appearance</legend>
@@ -491,12 +594,6 @@
       <label class="block" title="Background color of the terminal window, e.g., #041204.">Default Background Color:
         <input type="color" id="bg-color" class="ml-2" v-model="bgColor">
         <input type="text" id="bg-color-hex" class="ml-2 border rounded p-1 w-24" v-model="bgColor">
-      </label>
-    </fieldset>
-    <fieldset class="p-4 border rounded-lg shadow" title="Configure audio options.">
-      <legend class="flex items-center gap-1">Audio</legend>
-      <label class="block" title="Directory scanned for additional enter key audio clips.">Custom Sound Directory:
-        <input type="text" class="ml-2 border rounded p-1 w-full max-w-xs" v-model="customSoundDir" placeholder="e.g. sounds/custom">
       </label>
     </fieldset>
   </div>
@@ -516,6 +613,30 @@ const DEFAULT_BORDER_COLOR = '#008800';
 const BASE_SCREEN_COLOR = '#0c2c5f';
 const DEFAULT_DOWNLOAD_BASENAME = 'config';
 const INVALID_FILENAME_CHARS = /[<>:"/\\|?*\x00-\x1F]/g;
+const SOUND_FIELD_DEFINITIONS = [
+  { key: 'menuHover', label: 'Menu Hover', description: 'Played when menu options are highlighted.' },
+  { key: 'menuSelect', label: 'Menu Select', description: 'Played when a menu option is chosen.' },
+  { key: 'typingChar', label: 'Typing Character', description: 'Played while the terminal types characters.' },
+  { key: 'enterKey', label: 'Enter Key', description: 'Played when input is confirmed.' },
+  { key: 'wordHover', label: 'Hacking Word Hover', description: 'Played when hovering hacking words.' },
+  { key: 'charScroll', label: 'Character Scroll Loop', description: 'Looped while text scrolls across the screen.' },
+  { key: 'passwordSuccess', label: 'Password Success', description: 'Played when the password guess is correct.' },
+  { key: 'passwordFailure', label: 'Password Failure', description: 'Played when the password guess is incorrect.' },
+  { key: 'prefOpen', label: 'Preferences Open', description: 'Played when opening the preferences menu.' },
+  { key: 'prefClose', label: 'Preferences Close', description: 'Played when closing the preferences menu.' },
+  { key: 'builderLaunch', label: 'Open Builder', description: 'Played when opening the configuration builder.' },
+  { key: 'powerInsert', label: 'Load Config (Insert)', description: 'Played when selecting a configuration file.' },
+  { key: 'powerEject', label: 'Config Menu (Eject)', description: 'Played when opening the configuration picker.' },
+  { key: 'powerOn', label: 'Power On', description: 'Played when the terminal powers on.' },
+  { key: 'powerOff', label: 'Power Off', description: 'Played when the terminal powers down.' }
+];
+const SOUND_FIELD_KEYS = SOUND_FIELD_DEFINITIONS.map(def => def.key);
+
+function createEmptySoundSettings(){
+  const settings={};
+  SOUND_FIELD_KEYS.forEach(key=>{settings[key]='';});
+  return settings;
+}
 
 function sanitizeDownloadBaseName(name){
   const trimmed=(name||'').trim();
@@ -638,12 +759,12 @@ const app = Vue.createApp({
         bootSequence:[{text:'',type:'terminal',uid:crypto.randomUUID?crypto.randomUUID():Math.random()}],
         lockedBootSequence:[{text:'',type:'terminal',uid:crypto.randomUUID?crypto.randomUUID():Math.random()}],
         commands: [
-          {name:'back',screen:'',command:'',help:false,hacking:false,action:'back',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
-          {name:'help',screen:'',command:'',help:true,hacking:false,action:'help',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
-          {name:'?',screen:'',command:'',help:true,hacking:false,action:'help',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
-          {name:'syntaxhelper',screen:'',command:'',help:false,hacking:true,action:'syntaxhelper',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
-          {name:'ADMIN OVERRIDE',screen:'',command:'Access granted.',help:false,hacking:true,action:'adminoverride',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
-          {name:'ADMIN ALLOWANCES',screen:'',command:'Allowances set to 99.',help:false,hacking:true,action:'adminallowances',uid:crypto.randomUUID?crypto.randomUUID():Math.random()}
+          {name:'back',screen:'',command:'',sound:'',help:false,hacking:false,action:'back',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
+          {name:'help',screen:'',command:'',sound:'',help:true,hacking:false,action:'help',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
+          {name:'?',screen:'',command:'',sound:'',help:true,hacking:false,action:'help',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
+          {name:'syntaxhelper',screen:'',command:'',sound:'',help:false,hacking:true,action:'syntaxhelper',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
+          {name:'ADMIN OVERRIDE',screen:'',command:'Access granted.',sound:'',help:false,hacking:true,action:'adminoverride',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
+          {name:'ADMIN ALLOWANCES',screen:'',command:'Allowances set to 99.',sound:'',help:false,hacking:true,action:'adminallowances',uid:crypto.randomUUID?crypto.randomUUID():Math.random()}
         ],
         difficulties: [],
         difficultyChoice: 'Average',
@@ -656,6 +777,8 @@ const app = Vue.createApp({
         hackBorderColor: DEFAULT_BORDER_COLOR,
         hackingHeader: '',
         customSoundDir: '',
+        soundFieldDefs: SOUND_FIELD_DEFINITIONS,
+        soundSettings: createEmptySoundSettings(),
         hasUnsavedChanges: false,
         suppressUnsavedTracking: 0,
         domUnsavedListeners: [],
@@ -665,7 +788,8 @@ const app = Vue.createApp({
           commands: '',
           bootSequence: '',
           lockedBootSequence: '',
-          difficulties: ''
+          difficulties: '',
+          sounds: ''
         }
       };
   },
@@ -802,6 +926,17 @@ const app = Vue.createApp({
       },
       flush: 'sync'
     },
+    soundSettings: {
+      handler() {
+        const snapshot = this.serializeSounds();
+        const changed = snapshot !== this.collectionSnapshots.sounds;
+        this.collectionSnapshots.sounds = snapshot;
+        if(this.suppressUnsavedTracking || !changed) return;
+        this.markUnsaved();
+      },
+      deep: true,
+      flush: 'sync'
+    },
     customSoundDir: {
       handler() {
         this.markUnsaved();
@@ -866,22 +1001,47 @@ const app = Vue.createApp({
           textColor: scr.textColor,
           bgColor: scr.bgColor,
           borderColor: scr.borderColor,
-          items: scr.items.map(it=>({
-            text: it.text,
-            screen: it.screen,
-            command: it.command
-          }))
+          items: scr.items.map(it=>{
+            const sound=(it.sound||'').trim();
+            const base={
+              text: it.text,
+              screen: it.screen,
+              command: it.command
+            };
+            if(sound) base.sound=sound;
+            return base;
+          })
         })));
       },
       serializeCommands(){
-        return JSON.stringify(this.commands.map(cmd=>({
-          name: cmd.name,
-          screen: cmd.screen,
-          command: cmd.command,
-          help: !!cmd.help,
-          hacking: !!cmd.hacking,
-          action: cmd.action
+        return JSON.stringify(this.commands.map(cmd=>{
+          const sound=(cmd.sound||'').trim();
+          const base={
+            name: cmd.name,
+            screen: cmd.screen,
+            command: cmd.command,
+            help: !!cmd.help,
+            hacking: !!cmd.hacking,
+            action: cmd.action
+          };
+          if(sound) base.sound=sound;
+          return base;
         })));
+      },
+      serializeSounds(){
+        const snapshot=SOUND_FIELD_KEYS.map(key=>{
+          const value=(this.soundSettings[key]||'').trim();
+          return value?{key,value}:null;
+        }).filter(Boolean);
+        return JSON.stringify(snapshot);
+      },
+      collectSoundOverrides(){
+        const overrides={};
+        SOUND_FIELD_KEYS.forEach(key=>{
+          const value=(this.soundSettings[key]||'').trim();
+          if(value) overrides[key]=value;
+        });
+        return overrides;
       },
       serializeDifficulties(){
         return JSON.stringify(this.difficulties.map(diff=>({
@@ -896,6 +1056,7 @@ const app = Vue.createApp({
         this.collectionSnapshots.bootSequence = this.serializeBootSequence(this.bootSequence);
         this.collectionSnapshots.lockedBootSequence = this.serializeBootSequence(this.lockedBootSequence);
         this.collectionSnapshots.difficulties = this.serializeDifficulties();
+        this.collectionSnapshots.sounds = this.serializeSounds();
       },
       updateDownloadNameFromFile(fileName=''){
         this.runWithoutUnsavedTracking(()=>{
@@ -918,7 +1079,7 @@ const app = Vue.createApp({
         this.screens.push({
           id,
           color,
-          items:[{text:'', screen:'', command:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()}],
+          items:[{text:'', screen:'', command:'', sound:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()}],
           open:true,
           uid:crypto.randomUUID?crypto.randomUUID():Math.random(),
           textColor:text,
@@ -932,7 +1093,7 @@ const app = Vue.createApp({
         this.$nextTick(this.initSortables);
       },
       addCommand() {
-        this.commands.push({name:'',screen:'',command:'',help:false,hacking:false,action:'',uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+        this.commands.push({name:'',screen:'',command:'',sound:'',help:false,hacking:false,action:'',uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
       },
       removeCommand(idx) {
         this.commands.splice(idx,1);
@@ -948,7 +1109,7 @@ const app = Vue.createApp({
         [arr[idx], arr[idx + 1]] = [arr[idx + 1], arr[idx]];
       },
       addMenuItem(screen) {
-        screen.items.push({text:'', screen:'', command:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+        screen.items.push({text:'', screen:'', command:'', sound:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
         this.$nextTick(this.initSortables);
       },
         removeMenuItem(sIdx, iIdx) {
@@ -988,6 +1149,10 @@ const app = Vue.createApp({
           if (!this.invalidCommandScreenIds.has(cmd.uid)) return 'Screen ID';
           const screen = (cmd.screen || '').trim();
           return screen ? `Unknown screen "${screen}"` : 'Screen ID';
+        },
+        toggleSoundEditor(target){
+          if(!target) return;
+          target.showSoundEditor = !target.showSoundEditor;
         },
         addBootStep(seq) {
         seq.push({text:'', type:'terminal', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
@@ -1042,6 +1207,14 @@ const app = Vue.createApp({
           this.hackBorderColor = hackingStyle.borderColor || globalBorder;
           this.hackingHeader = (config.hacking && config.hacking.header) || '';
           this.customSoundDir = typeof config.customSoundDir === 'string' ? config.customSoundDir : '';
+          const soundSettings = createEmptySoundSettings();
+          if(config.sounds && typeof config.sounds === 'object'){
+            SOUND_FIELD_KEYS.forEach(key=>{
+              const value=config.sounds[key];
+              soundSettings[key]=typeof value==='string'?value.trim():'';
+            });
+          }
+          this.soundSettings = soundSettings;
           Object.entries(config.screens || {}).forEach(([id, data]) => {
             const color = generateScreenColor(BASE_SCREEN_COLOR, this.screens.length);
             const screen = {id, color, items:[], open:true, uid:crypto.randomUUID?crypto.randomUUID():Math.random(), textColor:globalText, bgColor:globalBg, borderColor:globalBorder};
@@ -1053,17 +1226,18 @@ const app = Vue.createApp({
             }
             items.forEach(item=>{
               if (typeof item === 'string') {
-                screen.items.push({text:item, screen:'', command:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+                screen.items.push({text:item, screen:'', command:'', sound:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
               } else {
                 screen.items.push({
                   text: item.text || '',
                   screen: item.screen || '',
                   command: item.command || '',
+                  sound: typeof item.sound === 'string' ? item.sound : '',
                   uid: crypto.randomUUID?crypto.randomUUID():Math.random()
                 });
               }
             });
-            if(!screen.items.length) screen.items.push({text:'', screen:'', command:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+            if(!screen.items.length) screen.items.push({text:'', screen:'', command:'', sound:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
             this.screens.push(screen);
           });
           Object.entries(config.commands || {}).forEach(([name, info])=>{
@@ -1071,6 +1245,7 @@ const app = Vue.createApp({
               name,
               screen: info.screen || '',
               command: info.command || '',
+              sound: typeof info.sound === 'string' ? info.sound : '',
               help: !!info.help,
               hacking: !!info.hacking,
               action: info.action || '',
@@ -1212,10 +1387,13 @@ const app = Vue.createApp({
           const text=(it.text||'').trimEnd();
           const screen=(it.screen||'').trim();
           const command=(it.command||'').trim();
+          const sound=(it.sound||'').trim();
           if(!text && !screen && !command) return;
-          if(screen && command){ items.push({text,screen,command}); }
-          else if(screen){ items.push({text,screen}); }
-          else if(command){ items.push({text,command}); }
+          const baseSound=sound?{sound}:null;
+          if(screen && command){ items.push(baseSound?{...baseSound,text,screen,command}:{text,screen,command}); }
+          else if(screen){ items.push(baseSound?{...baseSound,text,screen}:{text,screen}); }
+          else if(command){ items.push(baseSound?{...baseSound,text,command}:{text,command}); }
+          else if(baseSound){ items.push({ ...baseSound, text }); }
           else { items.push(text); }
         });
         const style = {};
@@ -1235,6 +1413,8 @@ const app = Vue.createApp({
         if(screen) obj.screen=screen;
         if(message) obj.command=message;
         if(action) obj.action=action;
+        const sound=(c.sound||'').trim();
+        if(sound) obj.sound=sound;
         if(c.help) obj.help=true;
         if(c.hacking) obj.hacking=true;
         if(Object.keys(obj).length) commandsObj[name]=obj;
@@ -1260,6 +1440,7 @@ const app = Vue.createApp({
       if (dudWords.length) hacking.dudWords = dudWords;
       if (this.hackingHeader) hacking.header = this.hackingHeader;
       const customSoundDir = (this.customSoundDir || '').trim();
+      const soundOverrides = this.collectSoundOverrides();
       this.runWithoutUnsavedTracking(()=>{
         this.downloadName = sanitizeDownloadBaseName(this.downloadName);
       });
@@ -1276,6 +1457,7 @@ const app = Vue.createApp({
         hacking
       };
       if(Object.keys(commandsObj).length) config.commands = commandsObj;
+      if(Object.keys(soundOverrides).length) config.sounds = soundOverrides;
       const blob = new Blob([JSON.stringify(config, null, 2)], {type: 'application/json'});
       const url = URL.createObjectURL(blob);
       const fileName = this.downloadFileName;

--- a/builder.html
+++ b/builder.html
@@ -1264,14 +1264,19 @@ const app = Vue.createApp({
             });
           });
           document.getElementById('locked').checked = config.locked || false;
-          const diffs = config.hacking?.difficulties || defaultDifficulties;
+          const hackingConfig = (config && typeof config.hacking === 'object') ? config.hacking : {};
+          const diffs = Array.isArray(hackingConfig.difficulties) ? hackingConfig.difficulties : defaultDifficulties;
           this.difficulties = [];
           diffs.forEach(d=>this.addDifficulty(d));
-          this.difficultyChoice = config.hacking?.difficulty ?? 'Random';
-          attemptsEl.value = config.hacking?.attempts ?? 4;
-          maxAttemptsEl.value = config.hacking?.maxAttempts ?? 4;
-          passwordEl.value = config.hacking?.password || '';
-          dudWordsEl.value = (config.hacking?.dudWords || []).join(', ');
+          const selectedDifficulty = hackingConfig.difficulty;
+          this.difficultyChoice = selectedDifficulty == null ? 'Random' : selectedDifficulty;
+          const attemptsValue = hackingConfig.attempts;
+          attemptsEl.value = attemptsValue == null ? 4 : attemptsValue;
+          const maxAttemptsValue = hackingConfig.maxAttempts;
+          maxAttemptsEl.value = maxAttemptsValue == null ? 4 : maxAttemptsValue;
+          passwordEl.value = hackingConfig.password || '';
+          const dudWords = Array.isArray(hackingConfig.dudWords) ? hackingConfig.dudWords : [];
+          dudWordsEl.value = dudWords.join(', ');
           this.$nextTick(this.initSortables);
         });
         this.resetUnsavedChanges();
@@ -1328,7 +1333,10 @@ const app = Vue.createApp({
         }
         if(event) event.preventDefault();
         if(!this.confirmNavigation()) return;
-        const href = event?.currentTarget?.getAttribute('href') || 'index.html';
+        const hrefTarget = event && event.currentTarget && typeof event.currentTarget.getAttribute === 'function'
+          ? event.currentTarget.getAttribute('href')
+          : null;
+        const href = hrefTarget || 'index.html';
         const go=()=>{ window.location.href = href; };
         if(typeof playSound === 'function'){
           const audio=playSound('Pip/select3.wav');

--- a/builder.html
+++ b/builder.html
@@ -474,6 +474,18 @@
           :title="commandScreenTitle(cmd)"
         >
         <input v-model="cmd.command" class="border rounded p-1 w-32" placeholder="Response">
+        <div class="flex flex-col w-48">
+          <label class="flex items-center gap-1 text-sm" :title="commandActionTooltip(cmd.action)">
+            Action:
+            <select v-model="cmd.action" class="border rounded p-1 w-36">
+              <option v-if="commandActionIsCustom(cmd.action)" :value="cmd.action">Custom: {{ cmd.action }}</option>
+              <option v-for="opt in commandActionOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+            </select>
+          </label>
+          <p v-if="commandActionTooltip(cmd.action)" class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            {{ commandActionTooltip(cmd.action) }}
+          </p>
+        </div>
         <button
           type="button"
           class="action-btn sound-toggle-btn"
@@ -631,6 +643,14 @@ const SOUND_FIELD_DEFINITIONS = [
   { key: 'powerOff', label: 'Power Off', description: 'Played when the terminal powers down.' }
 ];
 const SOUND_FIELD_KEYS = SOUND_FIELD_DEFINITIONS.map(def => def.key);
+const COMMAND_ACTION_OPTIONS = [
+  { value: '', label: 'None', description: 'No special handling. Uses screen/command fields as entered.' },
+  { value: 'back', label: 'Back', description: 'Returns to the previous menu screen.' },
+  { value: 'help', label: 'Help', description: 'Displays the built-in help text.' },
+  { value: 'syntaxhelper', label: 'Syntax Helper', description: 'Opens the syntax helper screen.' },
+  { value: 'adminoverride', label: 'Admin Override', description: 'Unlocks a locked terminal immediately.' },
+  { value: 'adminallowances', label: 'Admin Allowances', description: 'Applies allowances to the current terminal session.' }
+];
 
 function createUid(){
   if(typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'){
@@ -788,8 +808,10 @@ const app = Vue.createApp({
         hackBorderColor: DEFAULT_BORDER_COLOR,
         hackingHeader: '',
         customSoundDir: '',
+        extraSoundOverrides: {},
         soundFieldDefs: SOUND_FIELD_DEFINITIONS,
         soundSettings: createEmptySoundSettings(),
+        commandActionOptions: COMMAND_ACTION_OPTIONS,
         hasUnsavedChanges: false,
         suppressUnsavedTracking: 0,
         domUnsavedListeners: [],
@@ -948,6 +970,17 @@ const app = Vue.createApp({
       deep: true,
       flush: 'sync'
     },
+    extraSoundOverrides: {
+      handler() {
+        const snapshot = this.serializeSounds();
+        const changed = snapshot !== this.collectionSnapshots.sounds;
+        this.collectionSnapshots.sounds = snapshot;
+        if(this.suppressUnsavedTracking || !changed) return;
+        this.markUnsaved();
+      },
+      deep: true,
+      flush: 'sync'
+    },
     customSoundDir: {
       handler() {
         this.markUnsaved();
@@ -1040,14 +1073,24 @@ const app = Vue.createApp({
         })));
       },
       serializeSounds(){
-        const snapshot=SOUND_FIELD_KEYS.map(key=>{
-          const value=(this.soundSettings[key]||'').trim();
-          return value?{key,value}:null;
-        }).filter(Boolean);
-        return JSON.stringify(snapshot);
+        const snapshot={};
+        SOUND_FIELD_KEYS.forEach(key=>{
+          snapshot[key]=(this.soundSettings[key]||'').trim();
+        });
+        Object.entries(this.extraSoundOverrides || {}).forEach(([key,value])=>{
+          snapshot[key]=typeof value==='string'?value:'';
+        });
+        const extraKeys=Object.keys(this.extraSoundOverrides || {}).filter(key=>!SOUND_FIELD_KEYS.includes(key)).sort();
+        const orderedKeys=[...SOUND_FIELD_KEYS, ...extraKeys];
+        return JSON.stringify(snapshot, orderedKeys);
       },
       collectSoundOverrides(){
         const overrides={};
+        Object.entries(this.extraSoundOverrides || {}).forEach(([key,value])=>{
+          if(typeof value==='string'){
+            overrides[key]=value;
+          }
+        });
         SOUND_FIELD_KEYS.forEach(key=>{
           const value=(this.soundSettings[key]||'').trim();
           if(value) overrides[key]=value;
@@ -1165,6 +1208,16 @@ const app = Vue.createApp({
           if(!target) return;
           target.showSoundEditor = !target.showSoundEditor;
         },
+        commandActionTooltip(action){
+          const match=this.commandActionOptions.find(opt=>opt.value===action);
+          if(match) return match.description;
+          if(action) return `Custom action "${action}" will be preserved.`;
+          return '';
+        },
+        commandActionIsCustom(action){
+          if(!action) return false;
+          return !this.commandActionOptions.some(opt=>opt.value===action);
+        },
         addBootStep(seq) {
         seq.push({text:'', type:'terminal', uid:createUid()});
         this.$nextTick(this.initSortables);
@@ -1219,13 +1272,19 @@ const app = Vue.createApp({
           this.hackingHeader = (config.hacking && config.hacking.header) || '';
           this.customSoundDir = typeof config.customSoundDir === 'string' ? config.customSoundDir : '';
           const soundSettings = createEmptySoundSettings();
+          const extraSounds = {};
           if(config.sounds && typeof config.sounds === 'object'){
-            SOUND_FIELD_KEYS.forEach(key=>{
-              const value=config.sounds[key];
-              soundSettings[key]=typeof value==='string'?value.trim():'';
+            Object.entries(config.sounds).forEach(([key,value])=>{
+              if(typeof value!=='string') return;
+              if(SOUND_FIELD_KEYS.includes(key)){
+                soundSettings[key]=value.trim();
+              }else{
+                extraSounds[key]=value;
+              }
             });
           }
           this.soundSettings = soundSettings;
+          this.extraSoundOverrides = extraSounds;
           Object.entries(config.screens || {}).forEach(([id, data]) => {
             const color = generateScreenColor(BASE_SCREEN_COLOR, this.screens.length);
             const screen = {id, color, items:[], open:true, uid:createUid(), textColor:globalText, bgColor:globalBg, borderColor:globalBorder};
@@ -1407,13 +1466,22 @@ const app = Vue.createApp({
           const screen=(it.screen||'').trim();
           const command=(it.command||'').trim();
           const sound=(it.sound||'').trim();
-          if(!text && !screen && !command) return;
-          const baseSound=sound?{sound}:null;
-          if(screen && command){ items.push(baseSound?{...baseSound,text,screen,command}:{text,screen,command}); }
-          else if(screen){ items.push(baseSound?{...baseSound,text,screen}:{text,screen}); }
-          else if(command){ items.push(baseSound?{...baseSound,text,command}:{text,command}); }
-          else if(baseSound){ items.push({ ...baseSound, text }); }
-          else { items.push(text); }
+          if(!text && !screen && !command && !sound) return;
+          const hasSound=!!sound;
+          const base=hasSound?{sound}:{};
+          if(screen && command){
+            items.push({...base, text, screen, command});
+          }else if(screen){
+            items.push({...base, text, screen});
+          }else if(command){
+            items.push({...base, text, command});
+          }else if(hasSound){
+            const soundOnly={...base};
+            if(text) soundOnly.text=text;
+            items.push(soundOnly);
+          }else{
+            items.push(text);
+          }
         });
         const style = {};
         if(scr.textColor !== textColor) style.textColor = scr.textColor;

--- a/builder.html
+++ b/builder.html
@@ -632,6 +632,17 @@ const SOUND_FIELD_DEFINITIONS = [
 ];
 const SOUND_FIELD_KEYS = SOUND_FIELD_DEFINITIONS.map(def => def.key);
 
+function createUid(){
+  if(typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'){
+    try{
+      return crypto.randomUUID();
+    }catch(e){
+      // Ignore and fall back to Math.random
+    }
+  }
+  return Math.random().toString(36).slice(2);
+}
+
 function createEmptySoundSettings(){
   const settings={};
   SOUND_FIELD_KEYS.forEach(key=>{settings[key]='';});
@@ -756,15 +767,15 @@ const app = Vue.createApp({
         downloadName: DEFAULT_DOWNLOAD_BASENAME,
         downloadUrl: '',
         screens: [],
-        bootSequence:[{text:'',type:'terminal',uid:crypto.randomUUID?crypto.randomUUID():Math.random()}],
-        lockedBootSequence:[{text:'',type:'terminal',uid:crypto.randomUUID?crypto.randomUUID():Math.random()}],
+        bootSequence:[{text:'',type:'terminal',uid:createUid()}],
+        lockedBootSequence:[{text:'',type:'terminal',uid:createUid()}],
         commands: [
-          {name:'back',screen:'',command:'',sound:'',help:false,hacking:false,action:'back',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
-          {name:'help',screen:'',command:'',sound:'',help:true,hacking:false,action:'help',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
-          {name:'?',screen:'',command:'',sound:'',help:true,hacking:false,action:'help',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
-          {name:'syntaxhelper',screen:'',command:'',sound:'',help:false,hacking:true,action:'syntaxhelper',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
-          {name:'ADMIN OVERRIDE',screen:'',command:'Access granted.',sound:'',help:false,hacking:true,action:'adminoverride',uid:crypto.randomUUID?crypto.randomUUID():Math.random()},
-          {name:'ADMIN ALLOWANCES',screen:'',command:'Allowances set to 99.',sound:'',help:false,hacking:true,action:'adminallowances',uid:crypto.randomUUID?crypto.randomUUID():Math.random()}
+          {name:'back',screen:'',command:'',sound:'',help:false,hacking:false,action:'back',uid:createUid()},
+          {name:'help',screen:'',command:'',sound:'',help:true,hacking:false,action:'help',uid:createUid()},
+          {name:'?',screen:'',command:'',sound:'',help:true,hacking:false,action:'help',uid:createUid()},
+          {name:'syntaxhelper',screen:'',command:'',sound:'',help:false,hacking:true,action:'syntaxhelper',uid:createUid()},
+          {name:'ADMIN OVERRIDE',screen:'',command:'Access granted.',sound:'',help:false,hacking:true,action:'adminoverride',uid:createUid()},
+          {name:'ADMIN ALLOWANCES',screen:'',command:'Allowances set to 99.',sound:'',help:false,hacking:true,action:'adminallowances',uid:createUid()}
         ],
         difficulties: [],
         difficultyChoice: 'Average',
@@ -1079,9 +1090,9 @@ const app = Vue.createApp({
         this.screens.push({
           id,
           color,
-          items:[{text:'', screen:'', command:'', sound:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()}],
+          items:[{text:'', screen:'', command:'', sound:'', uid:createUid()}],
           open:true,
-          uid:crypto.randomUUID?crypto.randomUUID():Math.random(),
+          uid:createUid(),
           textColor:text,
           bgColor:bg,
           borderColor:border
@@ -1093,7 +1104,7 @@ const app = Vue.createApp({
         this.$nextTick(this.initSortables);
       },
       addCommand() {
-        this.commands.push({name:'',screen:'',command:'',sound:'',help:false,hacking:false,action:'',uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+        this.commands.push({name:'',screen:'',command:'',sound:'',help:false,hacking:false,action:'',uid:createUid()});
       },
       removeCommand(idx) {
         this.commands.splice(idx,1);
@@ -1109,7 +1120,7 @@ const app = Vue.createApp({
         [arr[idx], arr[idx + 1]] = [arr[idx + 1], arr[idx]];
       },
       addMenuItem(screen) {
-        screen.items.push({text:'', screen:'', command:'', sound:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+        screen.items.push({text:'', screen:'', command:'', sound:'', uid:createUid()});
         this.$nextTick(this.initSortables);
       },
         removeMenuItem(sIdx, iIdx) {
@@ -1155,7 +1166,7 @@ const app = Vue.createApp({
           target.showSoundEditor = !target.showSoundEditor;
         },
         addBootStep(seq) {
-        seq.push({text:'', type:'terminal', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+        seq.push({text:'', type:'terminal', uid:createUid()});
         this.$nextTick(this.initSortables);
         },
         removeBootStep(seq, idx) {
@@ -1175,7 +1186,7 @@ const app = Vue.createApp({
         initSortables() {
         },
       addDifficulty(d={name:'', wordCount:[1,1], length:[1,1]}) {
-        this.difficulties.push({...d, open:false, uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+        this.difficulties.push({...d, open:false, uid:createUid()});
         this.$nextTick(this.initSortables);
       },
       removeDifficulty(idx) {
@@ -1188,10 +1199,10 @@ const app = Vue.createApp({
           this.hideGenerationFeedback();
           document.getElementById('titles').value = (config.titleLines || []).join('\n');
           document.getElementById('headers').value = (config.headerLines || []).join('\n');
-          this.bootSequence = (config.bootSequence || []).map(s=>({...s, uid:crypto.randomUUID?crypto.randomUUID():Math.random()}));
-          this.lockedBootSequence = (config.lockedBootSequence || []).map(s=>({...s, uid:crypto.randomUUID?crypto.randomUUID():Math.random()}));
-          if(!this.bootSequence.length) this.bootSequence.push({text:'',type:'terminal',uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
-          if(!this.lockedBootSequence.length) this.lockedBootSequence.push({text:'',type:'terminal',uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+          this.bootSequence = (config.bootSequence || []).map(s=>({...s, uid:createUid()}));
+          this.lockedBootSequence = (config.lockedBootSequence || []).map(s=>({...s, uid:createUid()}));
+          if(!this.bootSequence.length) this.bootSequence.push({text:'',type:'terminal',uid:createUid()});
+          if(!this.lockedBootSequence.length) this.lockedBootSequence.push({text:'',type:'terminal',uid:createUid()});
           this.screens = [];
           this.commands = [];
           const style = config.style || {};
@@ -1217,7 +1228,7 @@ const app = Vue.createApp({
           this.soundSettings = soundSettings;
           Object.entries(config.screens || {}).forEach(([id, data]) => {
             const color = generateScreenColor(BASE_SCREEN_COLOR, this.screens.length);
-            const screen = {id, color, items:[], open:true, uid:crypto.randomUUID?crypto.randomUUID():Math.random(), textColor:globalText, bgColor:globalBg, borderColor:globalBorder};
+            const screen = {id, color, items:[], open:true, uid:createUid(), textColor:globalText, bgColor:globalBg, borderColor:globalBorder};
             const items = Array.isArray(data) ? data : (data.items || []);
             if(!Array.isArray(data) && data.style){
               if(data.style.textColor) screen.textColor = data.style.textColor;
@@ -1226,18 +1237,18 @@ const app = Vue.createApp({
             }
             items.forEach(item=>{
               if (typeof item === 'string') {
-                screen.items.push({text:item, screen:'', command:'', sound:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+                screen.items.push({text:item, screen:'', command:'', sound:'', uid:createUid()});
               } else {
                 screen.items.push({
                   text: item.text || '',
                   screen: item.screen || '',
                   command: item.command || '',
                   sound: typeof item.sound === 'string' ? item.sound : '',
-                  uid: crypto.randomUUID?crypto.randomUUID():Math.random()
+                  uid: createUid()
                 });
               }
             });
-            if(!screen.items.length) screen.items.push({text:'', screen:'', command:'', sound:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+            if(!screen.items.length) screen.items.push({text:'', screen:'', command:'', sound:'', uid:createUid()});
             this.screens.push(screen);
           });
           Object.entries(config.commands || {}).forEach(([name, info])=>{
@@ -1249,7 +1260,7 @@ const app = Vue.createApp({
               help: !!info.help,
               hacking: !!info.hacking,
               action: info.action || '',
-              uid: crypto.randomUUID?crypto.randomUUID():Math.random()
+              uid: createUid()
             });
           });
           document.getElementById('locked').checked = config.locked || false;

--- a/index.html
+++ b/index.html
@@ -530,16 +530,35 @@ async function loadConfig(cycle=currentCycle){
   commands={};
   if(cfg.commands){
     for(const [name,info] of Object.entries(cfg.commands)){
+      if(!info || typeof info!=='object') continue;
       const key=name.toLowerCase();
-      commands[key]=info;
-      if(info.help){
+      const commandInfo={...info};
+      if(typeof commandInfo.sound==='string'){
+        commandInfo.sound=commandInfo.sound.trim();
+        if(!commandInfo.sound) delete commandInfo.sound;
+      }else{
+        delete commandInfo.sound;
+      }
+      commands[key]=commandInfo;
+      if(commandInfo.help){
         if(!screens.help) screens.help=[];
         const item={text:`> ${name}`};
-        if(info.screen) item.screen=info.screen;
-        if(info.command) item.command=info.command;
+        if(commandInfo.screen) item.screen=commandInfo.screen;
+        if(commandInfo.command) item.command=commandInfo.command;
+        if(commandInfo.sound) item.sound=commandInfo.sound;
         const helpItems=screens.help;
         const retIdx=helpItems.findIndex(it=>typeof it==='object' && it.screen==='menu');
         if(retIdx>=0) helpItems.splice(retIdx,0,item); else helpItems.push(item);
+      }
+    }
+  }
+  soundOverrides=Object.create(null);
+  if(cfg.sounds && typeof cfg.sounds==='object'){
+    for(const key of SOUND_OVERRIDE_KEYS){
+      const value=cfg.sounds[key];
+      if(typeof value==='string'){
+        const trimmed=value.trim();
+        if(trimmed) soundOverrides[key]=trimmed;
       }
     }
   }
@@ -553,10 +572,11 @@ async function loadConfig(cycle=currentCycle){
     compSpeed=compBaseSpeed;
     if(compSpeedSelect) compSpeedSelect.value=String([80,90,95,100].includes(compBaseSpeed)?compBaseSpeed:90);
   }
-  if(savedCustomSoundDir===null && typeof cfg.customSoundDir==='string'){
+  if(typeof cfg.customSoundDir==='string'){
     await setCustomSoundDir(cfg.customSoundDir,{persist:false});
   }else{
-    await setCustomSoundDir(customSoundDir,{persist:false});
+    const preferred=savedCustomSoundDir!==null?savedCustomSoundDir:'';
+    await setCustomSoundDir(preferred,{persist:false});
   }
   if(cfg.style){
     const {textColor, backgroundColor, borderColor}=cfg.style;
@@ -622,8 +642,11 @@ const configButton=document.getElementById('config-button');
 const historyEl=content;
 
 function handleConfigLoaded(){
-  const startSound=trackAudio(new Audio('Terminal 4/Insert.wav'));
-  startSound.play();
+  const customAudio=playOverrideSound('powerInsert',{volume:selectVolume});
+  if(!customAudio){
+    const startSound=trackAudio(new Audio('Terminal 4/Insert.wav'));
+    startSound.play();
+  }
   if(powered){
     powerButton.click();
   }
@@ -643,7 +666,10 @@ configFile.addEventListener('change',async e=>{
   }
 });
 configButton.addEventListener('click',()=>{
-  trackAudio(new Audio('Terminal 4/Eject.wav')).play();
+  const customAudio=playOverrideSound('powerEject',{volume:selectVolume});
+  if(!customAudio){
+    trackAudio(new Audio('Terminal 4/Eject.wav')).play();
+  }
   configFile.click();
 });
 window.addEventListener('message', e => { uploadedConfig = e.data; handleConfigLoaded(); });
@@ -713,16 +739,26 @@ const userSpeedSelect=document.getElementById('user-speed-select');
 const compSpeedSelect=document.getElementById('comp-speed-select');
 const customSoundInput=document.getElementById('custom-sound-dir');
 const builderButton=document.getElementById('builder-button');
+const SOUND_OVERRIDE_KEYS=['menuHover','menuSelect','typingChar','enterKey','wordHover','charScroll','passwordSuccess','passwordFailure','prefOpen','prefClose','builderLaunch','powerInsert','powerEject','powerOn','powerOff'];
+let soundOverrides=Object.create(null);
 
 prefButton.addEventListener('click',()=>{
   const opening=prefMenu.style.display!=='flex';
   prefMenu.style.display=opening?'flex':'none';
+  const key=opening?'prefOpen':'prefClose';
+  const customAudio=playOverrideSound(key,{volume:selectVolume});
+  if(customAudio) return;
   const sound=trackAudio(new Audio(opening?'Pip/FavoriteOn.wav':'Pip/FavoriteOff.wav'));
   sound.play();
 });
 
 builderButton.addEventListener('click',e=>{
   e.preventDefault();
+  const customAudio=playOverrideSound('builderLaunch',{volume:selectVolume});
+  if(customAudio){
+    customAudio.addEventListener('ended',()=>{window.location.href=builderButton.href;},{once:true});
+    return;
+  }
   const audio=trackAudio(new Audio('Pip/holotapestart3.wav'));
   audio.play();
   audio.addEventListener('ended',()=>{window.location.href=builderButton.href;});
@@ -774,6 +810,7 @@ const enterCharAudios=[
   'Terminal 3/enter/charenter_03.wav'
 ].map(preloadAudio);
 const customAudioCache=new Map();
+const configuredSoundErrorHandlers=new WeakSet();
 let customEnterAudios=[];
 let customSoundLoadToken=0;
 userSpeedSelect.value=String([58,75,91,100].includes(userBaseSpeed)?userBaseSpeed:75);
@@ -1417,11 +1454,13 @@ async function handleCommand(cmd){
   const custom=commands[command];
   if(hackingActive){
     if(custom && custom.hacking){
+      playConfiguredSound(custom.sound);
       await executeCommand(custom, raw);
     }else{
       processGuess(raw.toUpperCase().slice(0,20),false);
     }
   }else if(custom){
+    playConfiguredSound(custom.sound);
     await executeCommand(custom, raw);
   }else{
     const match=currentOptions.find(o=>{
@@ -1463,15 +1502,22 @@ async function loadScrollSound(){
 }
 
 function playScrollSound(){
-  if(!scrollBuffer || !powered) return;
+  if(!powered) return;
   lastScrollTime=Date.now();
-  const src=audioCtx.createBufferSource();
-  src.buffer=scrollBuffer;
-  const gain=audioCtx.createGain();
-  gain.gain.value=scrollVolume;
-  src.connect(gain).connect(audioCtx.destination);
-  src.start();
-  scrollTimeout=setTrackedTimeout(playScrollSound,scrollIntervalMs);
+  const customAudio=playOverrideSound('charScroll',{volume:scrollVolume});
+  let played=!!customAudio;
+  if(scrollBuffer && !customAudio){
+    const src=audioCtx.createBufferSource();
+    src.buffer=scrollBuffer;
+    const gain=audioCtx.createGain();
+    gain.gain.value=scrollVolume;
+    src.connect(gain).connect(audioCtx.destination);
+    src.start();
+    played=true;
+  }
+  if(played){
+    scrollTimeout=setTrackedTimeout(playScrollSound,scrollIntervalMs);
+  }
 }
 function startScrollSound(){
   if(scrollTimeout || !powered) return;
@@ -1521,11 +1567,15 @@ function stopFanHum(){
 
 function playFocusSound(){
   if(!powered) return;
+  const customAudio=playOverrideSound('menuHover',{volume:focusVolume});
+  if(customAudio) return;
   playCachedAudio(focusAudio,focusVolume);
 }
 
 function playSelectSound(){
   if(!powered) return;
+  const customAudio=playOverrideSound('menuSelect',{volume:selectVolume});
+  if(customAudio) return;
   const files=[
     'Terminal 4/HDD/HDD1/HDD101.wav',
     'Terminal 4/HDD/HDD1/HDD102.wav',
@@ -1560,12 +1610,16 @@ function playSelectSound(){
 
 function playCharFocusSound(){
   if(!powered) return;
+  const customAudio=playOverrideSound('typingChar',{volume:focusVolume});
+  if(customAudio) return;
   const audio=charFocusAudios[Math.floor(Math.random()*charFocusAudios.length)];
   playCachedAudio(audio,focusVolume);
 }
 
 function playWordFocusSound(){
   if(!powered) return;
+  const customAudio=playOverrideSound('wordHover',{volume:focusVolume});
+  if(customAudio) return;
   const audio=wordFocusAudios[Math.floor(Math.random()*wordFocusAudios.length)];
   playCachedAudio(audio,focusVolume);
 }
@@ -1630,6 +1684,53 @@ function getCachedCustomAudio(src){
   const audio=preloadAudio(src);
   customAudioCache.set(src,audio);
   return audio;
+}
+
+function resolveSoundPath(soundPath){
+  const trimmed=(soundPath||'').trim();
+  if(!trimmed) return '';
+  if(/^[a-z]+:/i.test(trimmed) || trimmed.startsWith('//') || trimmed.startsWith('/')){
+    return trimmed;
+  }
+  if(!customSoundDir){
+    return trimmed;
+  }
+  const base=customSoundDir.endsWith('/')?customSoundDir:`${customSoundDir}/`;
+  try{
+    const baseUrl=new URL(base,window.location.href);
+    return new URL(trimmed,baseUrl).href;
+  }catch(err){
+    console.warn('Failed to resolve sound path',{sound:trimmed,customSoundDir},err);
+    return `${base}${trimmed.replace(/^\.\//,'')}`;
+  }
+}
+
+function playConfiguredSound(soundPath,{volume=selectVolume}={}){
+  const resolved=resolveSoundPath(soundPath);
+  if(!resolved) return null;
+  try{
+    const audio=getCachedCustomAudio(resolved);
+    if(!configuredSoundErrorHandlers.has(audio)){
+      audio.addEventListener('error',()=>{
+        if(customAudioCache.get(resolved)===audio){
+          customAudioCache.delete(resolved);
+        }
+        console.warn('Configured sound playback failed',resolved);
+      });
+      configuredSoundErrorHandlers.add(audio);
+    }
+    playCachedAudio(audio,volume);
+    return audio;
+  }catch(err){
+    console.warn('Failed to play configured sound',resolved,err);
+    return null;
+  }
+}
+
+function playOverrideSound(key,{volume=selectVolume}={}){
+  const sound=soundOverrides[key];
+  if(!sound) return null;
+  return playConfiguredSound(sound,{volume});
 }
 
 async function discoverCustomSoundSources(dir){
@@ -1740,6 +1841,8 @@ function normalizeAudioSources(entries,baseUrl){
 
 function playEnterCharSound(){
   if(!powered) return;
+  const customAudio=playOverrideSound('enterKey',{volume:selectVolume});
+  if(customAudio) return;
   const audio=enterCharAudios[Math.floor(Math.random()*enterCharAudios.length)];
   playCachedAudio(audio,selectVolume);
   if(customEnterAudios.length){
@@ -1756,6 +1859,9 @@ function playEnterCharSound(){
 
 function playPasswordResult(correct){
   if(!powered) return;
+  const key=correct?'passwordSuccess':'passwordFailure';
+  const customAudio=playOverrideSound(key,{volume:selectVolume});
+  if(customAudio) return;
   const file=correct?'Terminal 3/passgood.wav':'Terminal 3/passbad.wav';
   const audio=trackAudio(new Audio(file));
   audio.volume=selectVolume;
@@ -1997,6 +2103,7 @@ async function showScreen(name){
         div.tabIndex=0;
         await typeText(div,line.text);
         div.addEventListener('click',async()=>{
+          playConfiguredSound(line.sound);
           playSelectSound();
           if(line.screen){
             await showScreen(line.screen);
@@ -2083,8 +2190,11 @@ powerButton.addEventListener('click',async()=>{
   if(!powered){
     currentCycle++;
     const cycle=currentCycle;
-    const powerSound=trackAudio(new Audio('Terminal 3/poweron.mp3'));
-    powerSound.play();
+    const customAudio=playOverrideSound('powerOn',{volume:selectVolume});
+    if(!customAudio){
+      const powerSound=trackAudio(new Audio('Terminal 3/poweron.mp3'));
+      powerSound.play();
+    }
     powerScreen.style.display='none';
     updateScale();
     prevWidth=window.innerWidth;
@@ -2127,8 +2237,11 @@ powerButton.addEventListener('click',async()=>{
     header.innerHTML='';
     content.innerHTML='';
     applyScreenStyle(null);
-    const powerSound=trackAudio(new Audio('Terminal 3/poweroff.mp3'));
-    powerSound.play();
+    const customAudio=playOverrideSound('powerOff',{volume:selectVolume});
+    if(!customAudio){
+      const powerSound=trackAudio(new Audio('Terminal 3/poweroff.mp3'));
+      powerSound.play();
+    }
     powerScreen.style.display='flex';
     updateScale();
     prevWidth=window.innerWidth;


### PR DESCRIPTION
## Summary
- add a Sounds tab to the builder with a popup editor for menu/command sound paths and global override fields
- capture and serialize trimmed sound overrides so generated configs persist menu, command, and terminal effect audio selections
- update the runtime to resolve optional override clips for each terminal sound while keeping the default effects when no override is provided

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca43e34f188329b5f8f99863225fff