### PR TITLE
Add configurable sounds for menu options and commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,35 @@ Use the **Prefs** button beside the terminal to adjust audio volumes or typing
 speeds. Setting the **User Speed** or **Computer Speed** slider to `0` skips its
 respective animation entirely. Your chosen settings are stored in your browser
 and restored on the next visit.
+
+## Offline installation
+
+The terminal now ships with a Progressive Web App shell so it can keep working
+without an active network connection.
+
+1. Open `index.html` from a local server or your preferred hosting provider.
+2. Use your browser's install prompt (or the “Add to Home Screen” option on
+   mobile) to install **RobCo Termlink**.
+3. The first load caches `index.html`, the builder, configuration, fonts, and
+   all bundled audio. Future launches can run entirely offline.
+
+If you update the project files, revisit the page once online to refresh the
+cache. A lightweight static server such as `python -m http.server` still works
+for local testing, but the install step is no longer required once the cache is
+primed.
+
+## Custom audio sources
+
+Custom enter-key sounds can now come from either hosted URLs or a local folder:
+
+- Enter a web-accessible directory (for example, a GitHub Pages folder or a
+  local server) in **Custom Sound Source → Hosted URL** and the terminal will
+  fetch `.wav` and `.mp3` files as before.
+- Choose **Pick a local folder when the terminal loads** in the builder to have
+  the running terminal prompt for a folder using the File System Access API.
+  Once granted, the selection is remembered in the browser and works offline.
+
+When working offline, remember that hosted URLs still need to be reachable over
+HTTP/HTTPS. Local folders are only available in browsers that support
+`window.showDirectoryPicker`; if unavailable, the Hosted URL option remains the
+fallback.

--- a/builder.html
+++ b/builder.html
@@ -363,6 +363,7 @@
                     :title="menuItemScreenTitle(item)"
                   >
                   <input v-model="item.command" class="menu-command mr-1 border rounded p-1 w-32" placeholder="Command">
+                  <input v-model="item.sound" class="menu-sound mr-1 border rounded p-1 w-32" placeholder="Sound">
                   <button type="button" @click="moveMenuItemUp(sIdx, iIdx)" :disabled="iIdx===0" class="mr-1 action-btn" title="Move up">▲</button>
                   <button type="button" @click="moveMenuItemDown(sIdx, iIdx)" :disabled="iIdx===screen.items.length-1" class="mr-1 action-btn" title="Move down">▼</button>
                     <button type="button" @click="removeMenuItem(sIdx, iIdx)" class="action-btn" title="Remove item"><span class="w-4 h-4 flex items-center justify-center delete-icon">&times;</span></button>
@@ -419,6 +420,7 @@
           :title="commandScreenTitle(cmd)"
         >
         <input v-model="cmd.command" class="border rounded p-1 w-32" placeholder="Response">
+        <input v-model="cmd.sound" class="border rounded p-1 w-32" placeholder="Sound">
         <label class="flex items-center gap-1"><input type="checkbox" v-model="cmd.help">Help</label>
         <label class="flex items-center gap-1"><input type="checkbox" v-model="cmd.hacking">Hacking</label>
         <div class="flex gap-1">
@@ -869,7 +871,8 @@ const app = Vue.createApp({
           items: scr.items.map(it=>({
             text: it.text,
             screen: it.screen,
-            command: it.command
+            command: it.command,
+            sound: it.sound
           }))
         })));
       },
@@ -878,6 +881,7 @@ const app = Vue.createApp({
           name: cmd.name,
           screen: cmd.screen,
           command: cmd.command,
+          sound: cmd.sound,
           help: !!cmd.help,
           hacking: !!cmd.hacking,
           action: cmd.action
@@ -918,7 +922,7 @@ const app = Vue.createApp({
         this.screens.push({
           id,
           color,
-          items:[{text:'', screen:'', command:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()}],
+          items:[{text:'', screen:'', command:'', sound:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()}],
           open:true,
           uid:crypto.randomUUID?crypto.randomUUID():Math.random(),
           textColor:text,
@@ -932,7 +936,7 @@ const app = Vue.createApp({
         this.$nextTick(this.initSortables);
       },
       addCommand() {
-        this.commands.push({name:'',screen:'',command:'',help:false,hacking:false,action:'',uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+        this.commands.push({name:'',screen:'',command:'',sound:'',help:false,hacking:false,action:'',uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
       },
       removeCommand(idx) {
         this.commands.splice(idx,1);
@@ -948,7 +952,7 @@ const app = Vue.createApp({
         [arr[idx], arr[idx + 1]] = [arr[idx + 1], arr[idx]];
       },
       addMenuItem(screen) {
-        screen.items.push({text:'', screen:'', command:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+        screen.items.push({text:'', screen:'', command:'', sound:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
         this.$nextTick(this.initSortables);
       },
         removeMenuItem(sIdx, iIdx) {
@@ -1053,17 +1057,18 @@ const app = Vue.createApp({
             }
             items.forEach(item=>{
               if (typeof item === 'string') {
-                screen.items.push({text:item, screen:'', command:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+                screen.items.push({text:item, screen:'', command:'', sound:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
               } else {
                 screen.items.push({
                   text: item.text || '',
                   screen: item.screen || '',
                   command: item.command || '',
+                  sound: item.sound || '',
                   uid: crypto.randomUUID?crypto.randomUUID():Math.random()
                 });
               }
             });
-            if(!screen.items.length) screen.items.push({text:'', screen:'', command:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
+            if(!screen.items.length) screen.items.push({text:'', screen:'', command:'', sound:'', uid:crypto.randomUUID?crypto.randomUUID():Math.random()});
             this.screens.push(screen);
           });
           Object.entries(config.commands || {}).forEach(([name, info])=>{
@@ -1071,6 +1076,7 @@ const app = Vue.createApp({
               name,
               screen: info.screen || '',
               command: info.command || '',
+              sound: info.sound || '',
               help: !!info.help,
               hacking: !!info.hacking,
               action: info.action || '',
@@ -1212,11 +1218,17 @@ const app = Vue.createApp({
           const text=(it.text||'').trimEnd();
           const screen=(it.screen||'').trim();
           const command=(it.command||'').trim();
-          if(!text && !screen && !command) return;
-          if(screen && command){ items.push({text,screen,command}); }
-          else if(screen){ items.push({text,screen}); }
-          else if(command){ items.push({text,command}); }
-          else { items.push(text); }
+          const sound=(it.sound||'').trim();
+          if(!text && !screen && !command && !sound) return;
+          if(screen || command || sound){
+            const entry={text};
+            if(screen) entry.screen=screen;
+            if(command) entry.command=command;
+            if(sound) entry.sound=sound;
+            items.push(entry);
+          }else{
+            items.push(text);
+          }
         });
         const style = {};
         if(scr.textColor !== textColor) style.textColor = scr.textColor;
@@ -1231,10 +1243,12 @@ const app = Vue.createApp({
         const screen=(c.screen||'').trim();
         const message=(c.command||'').trim();
         const action=(c.action||'').trim();
+        const sound=(c.sound||'').trim();
         const obj={};
         if(screen) obj.screen=screen;
         if(message) obj.command=message;
         if(action) obj.action=action;
+        if(sound) obj.sound=sound;
         if(c.help) obj.help=true;
         if(c.hacking) obj.hacking=true;
         if(Object.keys(obj).length) commandsObj[name]=obj;

--- a/builder.html
+++ b/builder.html
@@ -497,8 +497,21 @@
     </fieldset>
     <fieldset class="p-4 border rounded-lg shadow" title="Configure audio options.">
       <legend class="flex items-center gap-1">Audio</legend>
-      <label class="block" title="Directory scanned for additional enter key audio clips.">Custom Sound Directory:
-        <input type="text" class="ml-2 border rounded p-1 w-full max-w-xs" v-model="customSoundDir" placeholder="e.g. sounds/custom">
+      <label class="block" title="Select where to load additional enter key audio clips.">Custom Sound Source:
+        <div class="mt-2 flex flex-col gap-2">
+          <label class="inline-flex items-center gap-2">
+            <input type="radio" class="border rounded p-1" value="url" v-model="customSoundMode">
+            <span>Hosted URL</span>
+          </label>
+          <div class="ml-6" v-if="customSoundMode==='url'">
+            <input type="text" class="border rounded p-1 w-full max-w-xs" v-model="customSoundDir" placeholder="e.g. sounds/custom">
+          </div>
+          <label class="inline-flex items-center gap-2">
+            <input type="radio" class="border rounded p-1" value="local" v-model="customSoundMode">
+            <span>Pick a local folder when the terminal loads</span>
+          </label>
+        </div>
+        <p class="mt-2 text-sm text-gray-600 dark:text-[color:rgba(122,255,122,0.7)]">Local folders require browser permission at runtime; hosted URLs continue to work on GitHub Pages or other servers.</p>
       </label>
     </fieldset>
   </div>
@@ -658,6 +671,7 @@ const app = Vue.createApp({
         hackBorderColor: DEFAULT_BORDER_COLOR,
         hackingHeader: '',
         customSoundDir: '',
+        customSoundMode: 'url',
         hasUnsavedChanges: false,
         suppressUnsavedTracking: 0,
         domUnsavedListeners: [],
@@ -806,6 +820,15 @@ const app = Vue.createApp({
     },
     customSoundDir: {
       handler() {
+        this.markUnsaved();
+      },
+      flush: 'sync'
+    },
+    customSoundMode: {
+      handler() {
+        if(this.customSoundMode==='local'){
+          this.customSoundDir='';
+        }
         this.markUnsaved();
       },
       flush: 'sync'
@@ -1045,7 +1068,23 @@ const app = Vue.createApp({
           this.hackBgColor = hackingStyle.backgroundColor || globalBg;
           this.hackBorderColor = hackingStyle.borderColor || globalBorder;
           this.hackingHeader = (config.hacking && config.hacking.header) || '';
-          this.customSoundDir = typeof config.customSoundDir === 'string' ? config.customSoundDir : '';
+          const src=config.customSoundSource;
+          if(src && typeof src==='object'){
+            const type=(src.type||src.kind||'').toLowerCase();
+            if(type==='local'){
+              this.customSoundMode='local';
+              this.customSoundDir='';
+            }else if(type==='url' && typeof src.value==='string'){
+              this.customSoundMode='url';
+              this.customSoundDir=src.value;
+            }else{
+              this.customSoundMode='url';
+              this.customSoundDir=typeof config.customSoundDir==='string'?config.customSoundDir:'';
+            }
+          }else{
+            this.customSoundMode='url';
+            this.customSoundDir=typeof config.customSoundDir==='string'?config.customSoundDir:'';
+          }
           Object.entries(config.screens || {}).forEach(([id, data]) => {
             const color = generateScreenColor(BASE_SCREEN_COLOR, this.screens.length);
             const screen = {id, color, items:[], open:true, uid:crypto.randomUUID?crypto.randomUUID():Math.random(), textColor:globalText, bgColor:globalBg, borderColor:globalBorder};
@@ -1274,6 +1313,13 @@ const app = Vue.createApp({
       if (dudWords.length) hacking.dudWords = dudWords;
       if (this.hackingHeader) hacking.header = this.hackingHeader;
       const customSoundDir = (this.customSoundDir || '').trim();
+      const customSoundMode = this.customSoundMode;
+      let customSoundSource = null;
+      if(customSoundMode === 'url' && customSoundDir){
+        customSoundSource = {type:'url', value:customSoundDir};
+      }else if(customSoundMode === 'local'){
+        customSoundSource = {type:'local'};
+      }
       this.runWithoutUnsavedTracking(()=>{
         this.downloadName = sanitizeDownloadBaseName(this.downloadName);
       });
@@ -1286,9 +1332,14 @@ const app = Vue.createApp({
         style,
         hackingStyle,
         locked,
-        customSoundDir,
         hacking
       };
+      if(customSoundMode === 'url' && customSoundDir){
+        config.customSoundDir = customSoundDir;
+      }
+      if(customSoundSource){
+        config.customSoundSource = customSoundSource;
+      }
       if(Object.keys(commandsObj).length) config.commands = commandsObj;
       const blob = new Blob([JSON.stringify(config, null, 2)], {type: 'application/json'});
       const url = URL.createObjectURL(blob);

--- a/config.json
+++ b/config.json
@@ -43,7 +43,7 @@
   "compSpeed": 90,
   "screens": {
     "menu": [
-      { "text": "> Protectron Schematics", "screen": "protectron" },
+      { "text": "> Protectron Schematics", "screen": "protectron", "sound": "Terminal 4/HDD/HDD1/HDD101.wav" },
       { "text": "> Mr. Handy Service Records", "screen": "handy" },
       { "text": "> Assaultron Combat Models", "screen": "assaultron" },
       { "text": "> Securitron Systems Control", "screen": "securitron" },
@@ -112,7 +112,7 @@
     "turret": [
       "== TURRET CONTROLS ==",
       "",
-      { "text": "> Activate Turrets", "command": "Live fire mode engaged" },
+      { "text": "> Activate Turrets", "command": "Live fire mode engaged", "sound": "Terminal 3/enter/charenter_02.wav" },
       { "text": "> Deactivate Turrets", "command": "Turrets placed in standby mode" },
       "",
       { "text": "> RETURN", "screen": "menu" }
@@ -143,7 +143,7 @@
     ]
   },
   "commands": {
-    "back": { "action": "back" },
+    "back": { "action": "back", "sound": "Terminal 4/HDD/HDD1/HDD102.wav" },
     "help": { "action": "help", "help": true },
     "?": { "action": "help", "help": true },
     "syntaxhelper": { "action": "syntaxhelper", "hacking": true },

--- a/icons/terminal.svg
+++ b/icons/terminal.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="24" fill="#041204"/>
+  <rect x="20" y="28" width="152" height="120" rx="12" fill="#0b2a0b" stroke="#21ff12" stroke-width="6"/>
+  <path d="M46 76l26 20-26 20" fill="none" stroke="#21ff12" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="96" y="118" width="48" height="12" rx="6" fill="#21ff12"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -537,6 +537,7 @@ async function loadConfig(cycle=currentCycle){
         const item={text:`> ${name}`};
         if(info.screen) item.screen=info.screen;
         if(info.command) item.command=info.command;
+        if(info.sound) item.sound=info.sound;
         const helpItems=screens.help;
         const retIdx=helpItems.findIndex(it=>typeof it==='object' && it.screen==='menu');
         if(retIdx>=0) helpItems.splice(retIdx,0,item); else helpItems.push(item);
@@ -1351,6 +1352,9 @@ async function executeCustomCommand(info){
 }
 
 async function executeCommand(info, rawCmd){
+  if(info.sound){
+    playConfiguredSound(info.sound);
+  }
   if(info.action){
     switch(info.action){
       case 'syntaxhelper':
@@ -1630,6 +1634,66 @@ function getCachedCustomAudio(src){
   const audio=preloadAudio(src);
   customAudioCache.set(src,audio);
   return audio;
+}
+
+const SOUND_SCHEME_PATTERN=/^[a-z][a-z0-9+.-]*:/i;
+
+function isAbsoluteSoundPath(path){
+  return SOUND_SCHEME_PATTERN.test(path) || path.startsWith('//') || path.startsWith('/');
+}
+
+function buildSoundCandidates(sound){
+  const trimmed=(sound||'').trim();
+  if(!trimmed) return [];
+  const candidates=[];
+  const seen=new Set();
+  const addCandidate=src=>{
+    if(!src || seen.has(src)) return;
+    seen.add(src);
+    candidates.push(src);
+  };
+  if(isAbsoluteSoundPath(trimmed)){
+    addCandidate(trimmed);
+    return candidates;
+  }
+  if(customSoundDir){
+    try{
+      const baseUrl=new URL(customSoundDir, window.location.href);
+      addCandidate(new URL(trimmed, baseUrl).href);
+    }catch(_err){
+      const base=customSoundDir.endsWith('/')?customSoundDir:`${customSoundDir}/`;
+      addCandidate(`${base}${trimmed.replace(/^\.?\/+/,'')}`);
+    }
+  }
+  addCandidate(trimmed);
+  return candidates;
+}
+
+function playConfiguredSound(sound,{volume=selectVolume}={}){
+  if(!powered) return false;
+  const candidates=buildSoundCandidates(sound);
+  if(!candidates.length) return false;
+  let started=false;
+  const playCandidate=index=>{
+    if(index>=candidates.length) return;
+    const src=candidates[index];
+    try{
+      const audio=getCachedCustomAudio(src);
+      const handleError=()=>{
+        audio.removeEventListener('error',handleError);
+        activeAudios.delete(audio);
+        playCandidate(index+1);
+      };
+      audio.addEventListener('error',handleError,{once:true});
+      playCachedAudio(audio,volume);
+      started=true;
+    }catch(err){
+      console.warn('Failed to play configured sound',src,err);
+      playCandidate(index+1);
+    }
+  };
+  playCandidate(0);
+  return started;
 }
 
 async function discoverCustomSoundSources(dir){
@@ -1997,7 +2061,13 @@ async function showScreen(name){
         div.tabIndex=0;
         await typeText(div,line.text);
         div.addEventListener('click',async()=>{
-          playSelectSound();
+          let soundPlayed=false;
+          if(line.sound){
+            soundPlayed=playConfiguredSound(line.sound);
+          }
+          if(!soundPlayed){
+            playSelectSound();
+          }
           if(line.screen){
             await showScreen(line.screen);
             if(line.command){

--- a/index.html
+++ b/index.html
@@ -3,7 +3,10 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<meta name="theme-color" content="#041204">
 <title>ROBCO INDUSTRIES (TM) TERMLINK PROTOCOL</title>
+<link rel="manifest" href="manifest.webmanifest">
+<link rel="icon" type="image/svg+xml" href="icons/terminal.svg">
 <style>
   @font-face{
     font-family:"FSEX300";
@@ -145,6 +148,36 @@
     border:calc(1px * var(--scale)) solid var(--border-color);
     flex:1;
     min-width:0;
+  }
+  #pref-menu .custom-sound-controls{
+    display:flex;
+    gap:calc(4px * var(--scale));
+    margin-top:calc(4px * var(--scale));
+    width:100%;
+  }
+  #pref-menu .custom-sound-controls input[type=text]{
+    margin-left:0;
+  }
+  #pref-menu .custom-sound-controls button{
+    background:var(--terminal-bg);
+    color:var(--text-color);
+    border:calc(1px * var(--scale)) solid var(--border-color);
+    font-family:inherit;
+    font-size:calc(12px * var(--scale) * 0.9);
+    padding:calc(3px * var(--scale)) calc(6px * var(--scale));
+    cursor:pointer;
+    white-space:nowrap;
+  }
+  #pref-menu .custom-sound-controls button:disabled{
+    opacity:0.5;
+    cursor:default;
+  }
+  #pref-menu .custom-sound-note{
+    display:block;
+    margin-top:calc(4px * var(--scale));
+    font-size:calc(11px * var(--scale) * 0.9);
+    color:var(--text-color);
+    opacity:0.8;
   }
   #pref-menu input[type=range]::-webkit-slider-thumb{
     -webkit-appearance:none;
@@ -357,7 +390,12 @@
           </select>
         </label>
         <label title="Directory scanned for additional custom enter key sounds.">Custom Sound Dir
-          <input type="text" id="custom-sound-dir" placeholder="e.g. sounds/custom">
+          <div class="custom-sound-controls">
+            <input type="text" id="custom-sound-dir" placeholder="e.g. sounds/custom">
+            <button type="button" id="custom-sound-picker">Pick Folder</button>
+            <button type="button" id="custom-sound-clear">Clear</button>
+          </div>
+          <span class="custom-sound-note" id="custom-sound-note">Supports hosted URLs or local folders.</span>
         </label>
       </div>
     </div>
@@ -465,6 +503,12 @@ function trackAudio(audio){
 }
 
 const AUDIO_FILE_PATTERN=/\.(wav|mp3)(?:\?.*)?$/i;
+const CUSTOM_SOUND_SOURCE_STORAGE_KEY='customSoundSource';
+const LEGACY_CUSTOM_SOUND_DIR_KEY='customSoundDir';
+const CUSTOM_SOUND_HANDLE_KEY='custom-sound-folder';
+const CUSTOM_SOUND_DB_NAME='terminal-sound-handles';
+const CUSTOM_SOUND_DB_STORE='handles';
+let directoryHandleDbPromise=null;
 const preloadedAudios=[];
 
 function preloadAudio(src){
@@ -554,11 +598,8 @@ async function loadConfig(cycle=currentCycle){
     compSpeed=compBaseSpeed;
     if(compSpeedSelect) compSpeedSelect.value=String([80,90,95,100].includes(compBaseSpeed)?compBaseSpeed:90);
   }
-  if(savedCustomSoundDir===null && typeof cfg.customSoundDir==='string'){
-    await setCustomSoundDir(cfg.customSoundDir,{persist:false});
-  }else{
-    await setCustomSoundDir(customSoundDir,{persist:false});
-  }
+  const configSoundSource=parseConfigCustomSoundSource(cfg);
+  await applyInitialCustomSoundSource(configSoundSource);
   if(cfg.style){
     const {textColor, backgroundColor, borderColor}=cfg.style;
     if(textColor) document.documentElement.style.setProperty('--text-color', textColor);
@@ -579,6 +620,47 @@ async function loadConfig(cycle=currentCycle){
   };
   startLocked=cfg.locked!==undefined?cfg.locked:true;
   if(hasHacked) startLocked=false;
+}
+
+function parseConfigCustomSoundSource(cfg){
+  if(!cfg) return null;
+  const src=cfg.customSoundSource;
+  if(src && typeof src==='object'){
+    const type=(src.type||src.kind||'').toLowerCase();
+    if(type==='url' && typeof src.value==='string'){
+      return {kind:'url',url:src.value};
+    }
+    if(type==='local'){
+      return {kind:'local'};
+    }
+  }
+  if(typeof cfg.customSoundDir==='string' && cfg.customSoundDir.trim()){
+    return {kind:'url',url:cfg.customSoundDir};
+  }
+  return null;
+}
+
+async function applyInitialCustomSoundSource(configSource){
+  if(savedCustomSoundSourceDescriptor){
+    const restored=await restoreSavedCustomSoundSource(savedCustomSoundSourceDescriptor);
+    savedCustomSoundSourceDescriptor=null;
+    if(restored) return;
+  }
+  if(configSource){
+    if(configSource.kind==='url'){
+      preferredCustomSoundMode='url';
+      await setCustomSoundSource({kind:'url',url:configSource.url},{persist:false});
+      return;
+    }
+    if(configSource.kind==='local'){
+      preferredCustomSoundMode='local';
+      updateCustomSoundInputDisplay();
+      await setCustomSoundSource(null,{persist:false});
+      return;
+    }
+  }
+  preferredCustomSoundMode=null;
+  await setCustomSoundSource(null,{persist:false});
 }
 
 const terminal=document.getElementById('terminal');
@@ -654,8 +736,9 @@ let typing=false;
 let baseDelay=10;
 let savedUserSpeed=localStorage.getItem('userSpeed');
 let savedCompSpeed=localStorage.getItem('compSpeed');
-let savedCustomSoundDir=localStorage.getItem('customSoundDir');
-let customSoundDir=savedCustomSoundDir!==null?savedCustomSoundDir:'';
+let savedCustomSoundSourceDescriptor=readSavedCustomSoundSource();
+let customSoundSource=null;
+let preferredCustomSoundMode=null;
 let userBaseSpeed=savedUserSpeed!==null?Number(savedUserSpeed):75;
 let compBaseSpeed=savedCompSpeed!==null?Number(savedCompSpeed):90;
 let userSpeed=userBaseSpeed;
@@ -713,6 +796,9 @@ const selectSlider=document.getElementById('select-volume');
 const userSpeedSelect=document.getElementById('user-speed-select');
 const compSpeedSelect=document.getElementById('comp-speed-select');
 const customSoundInput=document.getElementById('custom-sound-dir');
+const customSoundPicker=document.getElementById('custom-sound-picker');
+const customSoundClear=document.getElementById('custom-sound-clear');
+const customSoundNote=document.getElementById('custom-sound-note');
 const builderButton=document.getElementById('builder-button');
 
 prefButton.addEventListener('click',()=>{
@@ -743,15 +829,42 @@ scrollSlider.addEventListener('input',()=>{scrollVolume=scrollSlider.value/100;}
 focusSlider.addEventListener('input',()=>{focusVolume=focusSlider.value/100;});
 selectSlider.addEventListener('input',()=>{selectVolume=selectSlider.value/100;});
 if(customSoundInput){
-  customSoundInput.value=customSoundDir;
+  updateCustomSoundInputDisplay();
   customSoundInput.addEventListener('change',()=>{
-    setCustomSoundDir(customSoundInput.value,{persist:true});
+    if(customSoundInput.disabled) return;
+    setCustomSoundSourceFromInput(customSoundInput.value);
   });
   customSoundInput.addEventListener('keydown',e=>{
     if(e.key==='Enter'){
       e.preventDefault();
       customSoundInput.blur();
+      if(customSoundInput.disabled) return;
+      setCustomSoundSourceFromInput(customSoundInput.value);
     }
+  });
+}else{
+  updateCustomSoundInputDisplay();
+}
+if(customSoundPicker){
+  customSoundPicker.disabled=!('showDirectoryPicker' in window);
+  customSoundPicker.addEventListener('click',async ()=>{
+    if(!('showDirectoryPicker' in window)) return;
+    try{
+      const handle=await window.showDirectoryPicker();
+      if(!handle) return;
+      preferredCustomSoundMode=null;
+      await setCustomSoundSource({kind:'handle',handle,id:CUSTOM_SOUND_HANDLE_KEY});
+    }catch(err){
+      if(err && err.name!=='AbortError'){
+        console.warn('Custom folder selection failed',err);
+      }
+    }
+  });
+}
+if(customSoundClear){
+  customSoundClear.addEventListener('click',async ()=>{
+    preferredCustomSoundMode=null;
+    await setCustomSoundSource(null);
   });
 }
 const focusAudio=preloadAudio('Terminal 3/menu/menu_focus.wav');
@@ -777,6 +890,8 @@ const enterCharAudios=[
 const customAudioCache=new Map();
 let customEnterAudios=[];
 let customSoundLoadToken=0;
+const customLocalSoundLookup=new Map();
+let cleanupCustomSoundSources=null;
 userSpeedSelect.value=String([58,75,91,100].includes(userBaseSpeed)?userBaseSpeed:75);
 compSpeedSelect.value=String([80,90,95,100].includes(compBaseSpeed)?compBaseSpeed:90);
 userSpeedSelect.addEventListener('change',()=>{
@@ -1574,35 +1689,232 @@ function playWordFocusSound(){
   playCachedAudio(audio,focusVolume);
 }
 
-async function setCustomSoundDir(dir,{persist=true}={}){
-  const trimmed=(dir||'').trim();
-  if(persist){
-    if(trimmed){
-      localStorage.setItem('customSoundDir',trimmed);
-      savedCustomSoundDir=trimmed;
+function readSavedCustomSoundSource(){
+  try{
+    const raw=localStorage.getItem(CUSTOM_SOUND_SOURCE_STORAGE_KEY);
+    if(raw){
+      const parsed=JSON.parse(raw);
+      if(parsed && parsed.kind==='url' && typeof parsed.value==='string'){
+        return {kind:'url',value:parsed.value};
+      }
+      if(parsed && parsed.kind==='handle' && typeof parsed.id==='string'){
+        return {kind:'handle',id:parsed.id};
+      }
     }else{
-      localStorage.removeItem('customSoundDir');
-      savedCustomSoundDir=null;
+      const legacy=localStorage.getItem(LEGACY_CUSTOM_SOUND_DIR_KEY);
+      if(legacy!==null){
+        return {kind:'url',value:legacy};
+      }
     }
+  }catch(err){
+    console.warn('Failed to read saved custom sound source',err);
   }
-  customSoundDir=trimmed;
-  if(customSoundInput && customSoundInput.value!==trimmed){
-    customSoundInput.value=trimmed;
-  }
-  await loadCustomSoundClips(trimmed);
+  return null;
 }
 
-async function loadCustomSoundClips(dir){
+async function restoreSavedCustomSoundSource(descriptor){
+  if(!descriptor) return false;
+  if(descriptor.kind==='url' && typeof descriptor.value==='string'){
+    await setCustomSoundSource({kind:'url',url:descriptor.value},{persist:false});
+    return true;
+  }
+  if(descriptor.kind==='handle' && typeof descriptor.id==='string'){
+    const handle=await loadStoredDirectoryHandle(descriptor.id);
+    if(handle && await ensureDirectoryPermission(handle)){
+      await setCustomSoundSource({kind:'handle',handle,id:descriptor.id},{persist:false});
+      return true;
+    }
+    await deleteStoredDirectoryHandle(descriptor.id);
+  }
+  return false;
+}
+
+function updateCustomSoundInputDisplay(){
+  if(!customSoundInput) return;
+  if(customSoundSource && customSoundSource.kind==='handle'){
+    const name=customSoundSource.handle?.name||'Local Folder';
+    customSoundInput.value=`[Local] ${name}`;
+    customSoundInput.disabled=true;
+  }else{
+    const value=customSoundSource && customSoundSource.kind==='url'?customSoundSource.url:'';
+    customSoundInput.disabled=false;
+    customSoundInput.value=value||'';
+  }
+  if(customSoundNote){
+    if(customSoundSource && customSoundSource.kind==='handle'){
+      customSoundNote.textContent='Using a local folder. Browser permission is required to keep access.';
+    }else if(preferredCustomSoundMode==='local'){
+      customSoundNote.textContent='Pick a local folder to load custom enter-key sounds offline.';
+    }else{
+      customSoundNote.textContent='Supports hosted URLs or local folders.';
+    }
+  }
+  if(customSoundPicker){
+    customSoundPicker.disabled=!('showDirectoryPicker' in window);
+  }
+}
+
+async function setCustomSoundSourceFromInput(value){
+  const trimmed=(value||'').trim();
+  preferredCustomSoundMode=null;
+  if(!trimmed){
+    await setCustomSoundSource(null);
+  }else{
+    await setCustomSoundSource({kind:'url',url:trimmed});
+  }
+}
+
+async function setCustomSoundSource(source,{persist=true}={}){
+  let normalized=null;
+  if(source){
+    if(source.kind==='url'){
+      const trimmed=(source.url||source.value||'').trim();
+      if(trimmed){
+        normalized={kind:'url',url:trimmed};
+      }
+    }else if(source.kind==='handle' && source.handle){
+      if(await ensureDirectoryPermission(source.handle)){
+        normalized={kind:'handle',handle:source.handle,id:source.id||CUSTOM_SOUND_HANDLE_KEY};
+      }
+    }
+  }
+  customSoundSource=normalized;
+  updateCustomSoundInputDisplay();
+  if(persist){
+    await persistCustomSoundSource(customSoundSource);
+  }
+  await loadCustomSoundClips(customSoundSource);
+}
+
+async function persistCustomSoundSource(source){
+  try{
+    if(!source){
+      localStorage.removeItem(CUSTOM_SOUND_SOURCE_STORAGE_KEY);
+      localStorage.removeItem(LEGACY_CUSTOM_SOUND_DIR_KEY);
+      await deleteStoredDirectoryHandle(CUSTOM_SOUND_HANDLE_KEY);
+      return;
+    }
+    if(source.kind==='url'){
+      localStorage.setItem(CUSTOM_SOUND_SOURCE_STORAGE_KEY,JSON.stringify({kind:'url',value:source.url}));
+      localStorage.setItem(LEGACY_CUSTOM_SOUND_DIR_KEY,source.url);
+      await deleteStoredDirectoryHandle(CUSTOM_SOUND_HANDLE_KEY);
+      return;
+    }
+    if(source.kind==='handle'){
+      const id=source.id||CUSTOM_SOUND_HANDLE_KEY;
+      localStorage.setItem(CUSTOM_SOUND_SOURCE_STORAGE_KEY,JSON.stringify({kind:'handle',id}));
+      localStorage.removeItem(LEGACY_CUSTOM_SOUND_DIR_KEY);
+      await storeDirectoryHandle(id,source.handle);
+    }
+  }catch(err){
+    console.warn('Failed to persist custom sound source',err);
+  }
+}
+
+async function openDirectoryHandleDb(){
+  if(typeof indexedDB==='undefined') return null;
+  if(!directoryHandleDbPromise){
+    directoryHandleDbPromise=new Promise((resolve,reject)=>{
+      const request=indexedDB.open(CUSTOM_SOUND_DB_NAME,1);
+      request.onupgradeneeded=()=>{
+        try{
+          request.result.createObjectStore(CUSTOM_SOUND_DB_STORE);
+        }catch(_err){/* ignore */}
+      };
+      request.onsuccess=()=>resolve(request.result);
+      request.onerror=()=>reject(request.error);
+    }).catch(err=>{
+      console.warn('Failed to open directory handle database',err);
+      return null;
+    });
+  }
+  return directoryHandleDbPromise;
+}
+
+async function storeDirectoryHandle(id,handle){
+  const db=await openDirectoryHandleDb();
+  if(!db) return;
+  await new Promise((resolve,reject)=>{
+    const tx=db.transaction(CUSTOM_SOUND_DB_STORE,'readwrite');
+    tx.oncomplete=()=>resolve();
+    tx.onerror=()=>reject(tx.error);
+    tx.objectStore(CUSTOM_SOUND_DB_STORE).put(handle,id);
+  }).catch(err=>{
+    console.warn('Failed to store directory handle',err);
+  });
+}
+
+async function loadStoredDirectoryHandle(id){
+  const db=await openDirectoryHandleDb();
+  if(!db) return null;
+  return new Promise((resolve,reject)=>{
+    const tx=db.transaction(CUSTOM_SOUND_DB_STORE,'readonly');
+    tx.onerror=()=>reject(tx.error);
+    const request=tx.objectStore(CUSTOM_SOUND_DB_STORE).get(id);
+    request.onsuccess=()=>resolve(request.result||null);
+    request.onerror=()=>reject(request.error);
+  }).catch(err=>{
+    console.warn('Failed to read directory handle',err);
+    return null;
+  });
+}
+
+async function deleteStoredDirectoryHandle(id){
+  const db=await openDirectoryHandleDb();
+  if(!db) return;
+  await new Promise((resolve,reject)=>{
+    const tx=db.transaction(CUSTOM_SOUND_DB_STORE,'readwrite');
+    tx.oncomplete=()=>resolve();
+    tx.onerror=()=>reject(tx.error);
+    tx.objectStore(CUSTOM_SOUND_DB_STORE).delete(id);
+  }).catch(err=>{
+    console.warn('Failed to delete directory handle',err);
+  });
+}
+
+async function ensureDirectoryPermission(handle){
+  if(!handle || typeof handle.queryPermission!=='function') return true;
+  const opts={mode:'read'};
+  let status;
+  try{
+    status=await handle.queryPermission(opts);
+  }catch(_err){
+    status='prompt';
+  }
+  if(status==='granted') return true;
+  if(typeof handle.requestPermission!=='function') return status!=='denied';
+  try{
+    const requestResult=await handle.requestPermission(opts);
+    return requestResult==='granted';
+  }catch(_err){
+    return false;
+  }
+}
+
+async function loadCustomSoundClips(source){
   customSoundLoadToken++;
   const token=customSoundLoadToken;
+  cleanupCustomSoundSources?.();
+  cleanupCustomSoundSources=null;
   customEnterAudios=[];
-  if(!dir) return;
+  customAudioCache.clear();
+  customLocalSoundLookup.clear();
+  if(!source) return;
   try{
-    const sources=await discoverCustomSoundSources(dir);
-    if(token!==customSoundLoadToken) return;
+    const result=await discoverCustomSoundSources(source);
+    if(token!==customSoundLoadToken){
+      result.cleanup?.();
+      return;
+    }
+    cleanupCustomSoundSources=result.cleanup||null;
+    if(Array.isArray(result.lookupEntries)){
+      for(const entry of result.lookupEntries){
+        registerLocalSoundLookup(entry.path,entry.url);
+      }
+    }
     const audios=[];
     const seen=new Set();
-    for(const src of sources){
+    for(const src of result.sources||[]){
       if(!src || seen.has(src)) continue;
       seen.add(src);
       try{
@@ -1616,9 +1928,35 @@ async function loadCustomSoundClips(dir){
     customEnterAudios=audios;
   }catch(err){
     if(token===customSoundLoadToken){
-      console.warn('Failed to load custom sound directory',dir,err);
+      console.warn('Failed to load custom sound source',source,err);
     }
   }
+}
+
+function registerLocalSoundLookup(path,url){
+  if(!path || !url) return;
+  const normalized=normalizeLocalSoundKey(path);
+  addLocalLookup(normalized,url);
+  const base=normalizeLocalSoundKey(path.split('/').pop()||'');
+  if(base) addLocalLookup(base,url);
+}
+
+function addLocalLookup(key,url){
+  if(!key) return;
+  let list=customLocalSoundLookup.get(key);
+  if(!list){
+    list=[];
+    customLocalSoundLookup.set(key,list);
+  }
+  if(!list.includes(url)) list.push(url);
+}
+
+function normalizeLocalSoundKey(value){
+  return (value||'')
+    .replace(/^[.\\/]+/,'')
+    .replace(/\+/g,'/')
+    .replace(/\/+/g,'/')
+    .toLowerCase();
 }
 
 function removeFailedCustomAudio(src,audio){
@@ -1656,13 +1994,25 @@ function buildSoundCandidates(sound){
     addCandidate(trimmed);
     return candidates;
   }
-  if(customSoundDir){
-    try{
-      const baseUrl=new URL(customSoundDir, window.location.href);
-      addCandidate(new URL(trimmed, baseUrl).href);
-    }catch(_err){
-      const base=customSoundDir.endsWith('/')?customSoundDir:`${customSoundDir}/`;
-      addCandidate(`${base}${trimmed.replace(/^\.?\/+/,'')}`);
+  if(customSoundSource){
+    if(customSoundSource.kind==='url'){
+      try{
+        const baseUrl=new URL(customSoundSource.url,window.location.href);
+        addCandidate(new URL(trimmed,baseUrl).href);
+      }catch(_err){
+        const base=customSoundSource.url.endsWith('/')?customSoundSource.url:`${customSoundSource.url}/`;
+        addCandidate(`${base}${trimmed.replace(/^\.?\/+/,'')}`);
+      }
+    }else if(customSoundSource.kind==='handle'){
+      const normalized=normalizeLocalSoundKey(trimmed);
+      const matches=customLocalSoundLookup.get(normalized);
+      if(matches){
+        matches.forEach(addCandidate);
+      }
+      if(!matches){
+        const alt=customLocalSoundLookup.get(normalizeLocalSoundKey(trimmed.replace(/\\+/g,'/')));
+        if(alt) alt.forEach(addCandidate);
+      }
     }
   }
   addCandidate(trimmed);
@@ -1696,39 +2046,69 @@ function playConfiguredSound(sound,{volume=selectVolume}={}){
   return started;
 }
 
-async function discoverCustomSoundSources(dir){
-  const trimmed=(dir||'').trim();
-  if(!trimmed) return [];
-  const attempts=[trimmed];
-  if(!trimmed.endsWith('/')) attempts.push(`${trimmed}/`);
-  const errors=[];
-  for(const attempt of attempts){
-    try{
-      const res=await fetch(attempt,{cache:'no-store'});
-      if(!res.ok){
-        errors.push(new Error(`HTTP ${res.status} ${res.statusText||''}`.trim()));
-        continue;
+async function discoverCustomSoundSources(source){
+  if(!source) return {sources:[],lookupEntries:[]};
+  if(source.kind==='url'){
+    const trimmed=(source.url||'').trim();
+    if(!trimmed) return {sources:[],lookupEntries:[]};
+    const attempts=[trimmed];
+    if(!trimmed.endsWith('/')) attempts.push(`${trimmed}/`);
+    const errors=[];
+    for(const attempt of attempts){
+      try{
+        const res=await fetch(attempt,{cache:'no-store'});
+        if(!res.ok){
+          errors.push(new Error(`HTTP ${res.status} ${res.statusText||''}`.trim()));
+          continue;
+        }
+        const contentType=res.headers.get('content-type')||'';
+        if(contentType.includes('application/json')){
+          const data=await res.json();
+          return {sources:extractAudioSourcesFromJson(data,res.url),lookupEntries:[]};
+        }
+        const text=await res.text();
+        const sources=extractAudioSourcesFromText(text,res.url);
+        if(sources.length) return {sources,lookupEntries:[]};
+        if(AUDIO_FILE_PATTERN.test(res.url)){
+          return {sources:[res.url],lookupEntries:[]};
+        }
+        return {sources:[],lookupEntries:[]};
+      }catch(err){
+        errors.push(err);
       }
-      const contentType=res.headers.get('content-type')||'';
-      if(contentType.includes('application/json')){
-        const data=await res.json();
-        return extractAudioSourcesFromJson(data,res.url);
-      }
-      const text=await res.text();
-      const sources=extractAudioSourcesFromText(text,res.url);
-      if(sources.length) return sources;
-      if(AUDIO_FILE_PATTERN.test(res.url)){
-        return [res.url];
-      }
-      return [];
-    }catch(err){
-      errors.push(err);
     }
+    if(errors.length){
+      throw errors[errors.length-1];
+    }
+    return {sources:[],lookupEntries:[]};
   }
-  if(errors.length){
-    throw errors[errors.length-1];
+  if(source.kind==='handle' && source.handle){
+    const files=[];
+    const cleanup=[];
+    async function walk(dir,prefix=''){
+      for await (const entry of dir.values()){
+        if(entry.kind==='directory'){
+          await walk(entry,`${prefix}${entry.name}/`);
+        }else if(entry.kind==='file' && AUDIO_FILE_PATTERN.test(entry.name)){
+          try{
+            const file=await entry.getFile();
+            const url=URL.createObjectURL(file);
+            files.push({path:`${prefix}${entry.name}`,url});
+            cleanup.push(url);
+          }catch(err){
+            console.warn('Failed to read custom audio file',entry.name,err);
+          }
+        }
+      }
+    }
+    await walk(source.handle,'');
+    return {
+      sources:files.map(f=>f.url),
+      lookupEntries:files,
+      cleanup:()=>{cleanup.forEach(URL.revokeObjectURL);}
+    };
   }
-  return [];
+  return {sources:[],lookupEntries:[]};
 }
 
 function extractAudioSourcesFromJson(data,baseUrl){
@@ -2209,6 +2589,14 @@ powerButton.addEventListener('click',async()=>{
     hackingData=null;
   }
 });
+
+if('serviceWorker' in navigator){
+  window.addEventListener('load',()=>{
+    navigator.serviceWorker.register('service-worker.js').catch(err=>{
+      console.warn('Service worker registration failed',err);
+    });
+  });
+}
 </script>
 </body>
 </html>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "RobCo Termlink",
+  "short_name": "Termlink",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "#041204",
+  "theme_color": "#041204",
+  "icons": [
+    {
+      "src": "icons/terminal.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,197 @@
+const CACHE_VERSION = 'terminal-offline-v3';
+const PRECACHE_URLS = [
+  './',
+  'index.html',
+  'builder.html',
+  'config.json',
+  'Hacking Words.txt',
+  'builder-utils.js',
+  'fonts/FSEX300.ttf',
+  'manifest.webmanifest',
+  'icons/terminal.svg',
+  'Pip/Boot/Boot1.wav',
+  'Pip/Boot/Boot2.wav',
+  'Pip/Boot/Boot3.wav',
+  'Pip/Burst Static/BurstStatic01.wav',
+  'Pip/Burst Static/BurstStatic02.wav',
+  'Pip/Burst Static/BurstStatic03.wav',
+  'Pip/Burst Static/BurstStatic04.wav',
+  'Pip/Burst Static/BurstStatic05.wav',
+  'Pip/Burst Static/BurstStatic06.wav',
+  'Pip/Burst Static/BurstStatic07.wav',
+  'Pip/Burst Static/BurstStatic08.wav',
+  'Pip/Burst Static/BurstStatic09.wav',
+  'Pip/Burst Static/BurstStatic10.wav',
+  'Pip/Burst Static/BurstStatic11.wav',
+  'Pip/Burst Static/BurstStatic12.wav',
+  'Pip/Burst Static/BurstStatic13.wav',
+  'Pip/Burst Static/BurstStatic14.wav',
+  'Pip/Burst Static/BurstStatic15.wav',
+  'Pip/Burst Static/BurstStatic16.wav',
+  'Pip/Burst Static/BurstStatic17.wav',
+  'Pip/FavoriteMenuDown01.wav',
+  'Pip/FavoriteMenuDpad01.wav',
+  'Pip/FavoriteOff.wav',
+  'Pip/FavoriteOn.wav',
+  'Pip/Highlight4.wav',
+  'Pip/HolotapeInsert01.wav',
+  'Pip/LightOff.wav',
+  'Pip/LightOn.wav',
+  'Pip/RotaryHorizontal01.wav',
+  'Pip/RotaryHorizontal02.wav',
+  'Pip/RotaryVertical01.wav',
+  'Pip/RotaryVertical03.wav',
+  'Pip/Select.wav',
+  'Pip/holotapestart3.wav',
+  'Pip/holotapestop3.wav',
+  'Pip/mode3.wav',
+  'Pip/mousescroll.wav',
+  'Pip/scroll3.wav',
+  'Pip/select3.wav',
+  'Pip/tab3.wav',
+  'Pip/tuner3.wav',
+  'Terminal 3/charscroll.wav',
+  'Terminal 3/charscroll_lp.wav',
+  'Terminal 3/enter/charenter_01.wav',
+  'Terminal 3/enter/charenter_02.wav',
+  'Terminal 3/enter/charenter_03.wav',
+  'Terminal 3/fanhum_lp.wav',
+  'Terminal 3/menu/menu_cancel.wav',
+  'Terminal 3/menu/menu_focus.wav',
+  'Terminal 3/menu/menu_ok.wav',
+  'Terminal 3/menu/menu_prevnext.wav',
+  'Terminal 3/multiple/charmultiple_01.wav',
+  'Terminal 3/multiple/charmultiple_02.wav',
+  'Terminal 3/multiple/charmultiple_03.wav',
+  'Terminal 3/multiple/charmultiple_04.wav',
+  'Terminal 3/passbad.wav',
+  'Terminal 3/passgood.wav',
+  'Terminal 3/poweroff.mp3',
+  'Terminal 3/poweron.mp3',
+  'Terminal 3/single/charsingle_01.wav',
+  'Terminal 3/single/charsingle_02.wav',
+  'Terminal 3/single/charsingle_03.wav',
+  'Terminal 3/single/charsingle_04.wav',
+  'Terminal 3/single/charsingle_05.wav',
+  'Terminal 3/single/charsingle_06.wav',
+  'Terminal 4/Boot1.wav',
+  'Terminal 4/Boot2.wav',
+  'Terminal 4/Boot3.wav',
+  'Terminal 4/CharScroll_LP.wav',
+  'Terminal 4/Deploy Terminal.wav',
+  'Terminal 4/Eject.wav',
+  'Terminal 4/Enter key/CharEnter_01.wav',
+  'Terminal 4/Enter key/CharEnter_02.wav',
+  'Terminal 4/Enter key/CharEnter_03.wav',
+  'Terminal 4/FanHum.wav',
+  'Terminal 4/FanHum_LP.wav',
+  'Terminal 4/HDD/HDD1/HDD101.wav',
+  'Terminal 4/HDD/HDD1/HDD102.wav',
+  'Terminal 4/HDD/HDD1/HDD103.wav',
+  'Terminal 4/HDD/HDD1/HDD104.wav',
+  'Terminal 4/HDD/HDD1/HDD105.wav',
+  'Terminal 4/HDD/HDD1/HDD106.wav',
+  'Terminal 4/HDD/HDD1/HDD107.wav',
+  'Terminal 4/HDD/HDD1/HDD108.wav',
+  'Terminal 4/HDD/HDD1/HDD109.wav',
+  'Terminal 4/HDD/HDD1/HDD110.wav',
+  'Terminal 4/HDD/HDD1/HDD111.wav',
+  'Terminal 4/HDD/HDD1/HDD112.wav',
+  'Terminal 4/HDD/HDD1/HDD113.wav',
+  'Terminal 4/HDD/HDD1/HDD114.wav',
+  'Terminal 4/HDD/HDD1/HDD115.wav',
+  'Terminal 4/HDD/HDD2/HDD201.wav',
+  'Terminal 4/HDD/HDD2/HDD202.wav',
+  'Terminal 4/HDD/HDD2/HDD203.wav',
+  'Terminal 4/HDD/HDD2/HDD204.wav',
+  'Terminal 4/HDD/HDD2/HDD205.wav',
+  'Terminal 4/HDD/HDD2/HDD206.wav',
+  'Terminal 4/HDD/HDD2/HDD207.wav',
+  'Terminal 4/HDD/HDD2/HDD208.wav',
+  'Terminal 4/HDD/HDD2/HDD209.wav',
+  'Terminal 4/HDD/HDD2/HDD210.wav',
+  'Terminal 4/HDD/HDD2/HDD211.wav',
+  'Terminal 4/HDD/HDD2/HDD212.wav',
+  'Terminal 4/HDD/HDD2/HDD213.wav',
+  'Terminal 4/HDD/HDD2/HDD214.wav',
+  'Terminal 4/Insert.wav',
+  'Terminal 4/Multiple Keys/CharMultiple_01.wav',
+  'Terminal 4/Multiple Keys/CharMultiple_02.wav',
+  'Terminal 4/Multiple Keys/CharMultiple_03.wav',
+  'Terminal 4/Multiple Keys/CharMultiple_04.wav',
+  'Terminal 4/PassBad.wav',
+  'Terminal 4/PassGood.wav',
+  'Terminal 4/PasswordHelpAttempts.wav',
+  'Terminal 4/PasswordHelpDud.wav',
+  'Terminal 4/PortableFanHum.wav',
+  'Terminal 4/Program End/ProgramQuit_01.wav',
+  'Terminal 4/Program End/ProgramQuit_02.wav',
+  'Terminal 4/Program End/ProgramQuit_03.wav',
+  'Terminal 4/Program Start/ProgramLoad_01.wav',
+  'Terminal 4/Program Start/ProgramLoad_02.wav',
+  'Terminal 4/Program Start/ProgramLoad_03.wav',
+  'Terminal 4/Put up Terminal.wav',
+  'Terminal 4/Single Key/CharSingle_01.wav',
+  'Terminal 4/Single Key/CharSingle_02.wav',
+  'Terminal 4/Single Key/CharSingle_03.wav',
+  'Terminal 4/Single Key/CharSingle_04.wav',
+  'Terminal 4/Single Key/CharSingle_05.wav',
+  'https://cdn.tailwindcss.com',
+  'https://unpkg.com/vue@3/dist/vue.global.prod.js'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil((async () => {
+    const cache = await caches.open(CACHE_VERSION);
+    for (const url of PRECACHE_URLS) {
+      try {
+        await cache.add(new Request(url, { cache: 'reload' }));
+      } catch (err) {
+        console.warn('Failed to precache', url, err);
+      }
+    }
+    await self.skipWaiting();
+  })());
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil((async () => {
+    const keys = await caches.keys();
+    await Promise.all(keys.filter(key => key !== CACHE_VERSION).map(key => caches.delete(key)));
+    await self.clients.claim();
+  })());
+});
+
+self.addEventListener('fetch', event => {
+  const { request } = event;
+  if(request.method !== 'GET') return;
+
+  // Allow the network to handle byte range and other special requests.
+  if(request.headers.has('range')) return;
+
+  event.respondWith((async () => {
+    const cache = await caches.open(CACHE_VERSION);
+    const cached = await cache.match(request);
+    if(cached) {
+      return cached;
+    }
+    try {
+      const response = await fetch(request);
+      if(request.url.startsWith(self.location.origin) && response && response.ok && response.status !== 206){
+        try{
+          await cache.put(request, response.clone());
+        }catch(cacheErr){
+          // Some responses (e.g., opaque or binary streams) cannot be cached; ignore those failures.
+          console.debug('Cache put skipped for', request.url, cacheErr);
+        }
+      }
+      return response;
+    } catch (err) {
+      if(request.mode === 'navigate'){
+        const fallback = await cache.match('index.html');
+        if(fallback) return fallback;
+      }
+      throw err;
+    }
+  })());
+});


### PR DESCRIPTION
## Summary
- allow configuring optional sound paths for screen menu items and command definitions in the builder and exported config
- add UI fields and serialization/deserialization support so authors can edit the new sound values
- resolve and play configured sounds at runtime, falling back to existing audio where appropriate

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccea448a888329b81e15ec4a6d491d